### PR TITLE
Fix benefit icon display in German site

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -425,8 +425,8 @@
             box-shadow: var(--shadow-hover);
         }
 
-        .benefit-icon {
-            display: none;
+        .benefit-card .benefit-icon {
+            display: none !important;
         }
 
         .benefit-card h3 {


### PR DESCRIPTION
## Summary
- update CSS selector to explicitly hide benefit icons in the German page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6876695f16148323a058459f2b6d82b8