### PR TITLE
Fix RMC logo paths and omit duplicate asset

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -252,7 +252,7 @@
             height: 30px;
             background: var(--primary-green);
             border-radius: 4px;
-            background-image: url('images/rmclogo.png');
+            background-image: url('../images/rmclogo.png');
             background-size: contain;
             background-repeat: no-repeat;
             background-position: center;

--- a/en/index.html
+++ b/en/index.html
@@ -252,7 +252,7 @@
             height: 30px;
             background: var(--primary-green);
             border-radius: 4px;
-            background-image: url('images/rmclogo.png');
+            background-image: url('../images/rmclogo.png');
             background-size: contain;
             background-repeat: no-repeat;
             background-position: center;


### PR DESCRIPTION
## Summary
- update RMC logo CSS path for DE and EN pages
- remove redundant `rmclogo.png` asset from repo

## Testing
- `echo "no tests"`


------
https://chatgpt.com/codex/tasks/task_e_6876933843cc83239174e3ae02b49b7c