### PR TITLE
Expand English homepage with RMC services

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -3,24 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Cashless diesel refueling across Europe with our truck fuel card. Transparent billing, discounts & personal service. Get a quote now!">
-    <title>Truck Fuel Card Europe | Diesel Card for Transport & Fleet</title>
+    <meta name="description" content="Cashless fuel across Europe with our fuel card. Toll solutions for 17 countries. Prepaid credit card without credit check. All from one provider.">
+    <title>European Mobility Solutions | Fuel Card, Toll & Credit Card</title>
     <link rel="canonical" href="https://www.filo.cards/en/">
     <link rel="alternate" hreflang="de" href="https://www.filo.cards/de/">
     <link rel="alternate" hreflang="en" href="https://www.filo.cards/en/">
     <link rel="alternate" hreflang="tr" href="https://www.filo.cards/">
     <link rel="alternate" hreflang="x-default" href="https://www.filo.cards/de/">
-    <meta name="keywords" content="filo cards, truck fuel card europe, diesel card, commercial fuel card, fleet fuel card, fuel card trucking, diesel discount card, european fuel card, transport fuel card, filo fleet solutions">
+    <meta name="keywords" content="fuel card europe, truck fuel card, toll solutions, prepaid credit card, fleet management, RMC service, european mobility">
     <meta property="og:type" content="website">
     <meta property="og:locale" content="en_US">
     <meta property="og:site_name" content="Özkan Gökceviran">
-    <meta property="og:title" content="Truck Fuel Card Europe | Diesel Card for Transport & Fleet">
-    <meta property="og:description" content="Cashless diesel refueling across Europe with our truck fuel card. Transparent billing, discounts & personal service.">
+    <meta property="og:title" content="European Mobility Solutions | Fuel Card, Toll & Credit Card">
+    <meta property="og:description" content="Cashless fuel across Europe with our fuel card. Toll solutions for 17 countries. Prepaid credit card without credit check. All from one provider.">
     <meta property="og:url" content="https://www.filo.cards/en/">
     <meta property="og:image" content="https://www.filo.cards/images/europa-karte.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Truck Fuel Card Europe | Diesel Card for Transport & Fleet">
-    <meta name="twitter:description" content="Cashless diesel refueling across Europe with our truck fuel card.">
+    <meta name="twitter:title" content="European Mobility Solutions | Fuel Card, Toll & Credit Card">
+    <meta name="twitter:description" content="Cashless fuel across Europe with our fuel card.">
     <meta name="twitter:image" content="https://www.filo.cards/images/europa-karte.png">
     <script type="application/ld+json">
     {
@@ -939,12 +939,12 @@
             
             <div class="nav-right">
                 <ul class="nav-links">
-                    <li><a href="#start" data-lang="nav-start">Start</a></li>
+                    <li><a href="#start" data-lang="nav-start">Home</a></li>
                     <li><a href="#services" data-lang="nav-services">Services</a></li>
-                    <li><a href="#tankkarte" data-lang="nav-fuelcard">Tankkarte</a></li>
-                    <li><a href="#maut" data-lang="nav-toll">Maut</a></li>
-                    <li><a href="#kreditkarte" data-lang="nav-creditcard">Kreditkarte</a></li>
-                    <li><a href="#kontakt" data-lang="nav-contact">Kontakt</a></li>
+                    <li><a href="#tankkarte" data-lang="nav-fuelcard">Fuel Card</a></li>
+                    <li><a href="#maut" data-lang="nav-toll">Toll</a></li>
+                    <li><a href="#kreditkarte" data-lang="nav-creditcard">Credit Card</a></li>
+                    <li><a href="#kontakt" data-lang="nav-contact">Contact</a></li>
                     <li><a href="#faq" data-lang="nav-faq">FAQ</a></li>
                 </ul>
                 
@@ -971,17 +971,17 @@
         
         <div class="container">
             <div class="hero-content fade-in">
-                <h1 data-lang="hero-title">LKW-Tankkarte Europa | Bargeldlos Tanken für Spedition & Logistik</h1>
-                <p class="hero-subtitle" data-lang="hero-subtitle">Ihre Tankkarte für LKWs – europaweit bargeldlos tanken</p>
+                <h1 data-lang="hero-title">European Mobility Solutions | Fuel Card, Toll & Credit Card</h1>
+                <p class="hero-subtitle" data-lang="hero-subtitle">Your partner for Europe-wide mobility – from fuel to tolls</p>
                 
                 <ul class="benefits-list">
-                    <li data-lang="hero-benefit-1">Tankkarte für LKWs in Europa</li>
-                    <li data-lang="hero-benefit-2">Bargeldlos tanken an über 10.000 Tankstellen</li>
-                    <li data-lang="hero-benefit-3">Attraktive Dieselpreise und Rabatte</li>
-                    <li data-lang="hero-benefit-4">Transparente Abrechnung & volle Kostenkontrolle</li>
+                    <li data-lang="hero-benefit-1">Fuel card for 19 European countries</li>
+                    <li data-lang="hero-benefit-2">Toll solutions for 17 countries from one provider</li>
+                    <li data-lang="hero-benefit-3">Prepaid credit card without credit check</li>
+                    <li data-lang="hero-benefit-4">Transparent billing & full cost control</li>
                 </ul>
 
-                <a href="#kontakt" class="btn" data-lang="hero-cta">Jetzt Tankkarte anfragen</a>
+                <a href="#kontakt" class="btn" data-lang="hero-cta">Request fuel card now</a>
             </div>
         </div>
 </section>
@@ -993,23 +993,108 @@
             <div class="services-grid">
                 <div class="service-card">
                     <span class="service-icon">🚛</span>
-                    <h3 data-lang="service-1-title">RMC Tankkarte</h3>
-                    <p data-lang="service-1-desc">Tankkarte Beschreibung</p>
+                    <h3 data-lang="service-1-title">RMC Fuel Card</h3>
+                    <p data-lang="service-1-desc">Refuel cheaply across Europe at over 10,000 gas stations. No fees, attractive prices.</p>
+                    <div class="service-features">
+                        <span>19 Countries</span>
+                        <span>€0 Fees</span>
+                        <span>Austria: -1.5ct/L</span>
+                    </div>
                 </div>
                 <div class="service-card">
                     <span class="service-icon">💳</span>
-                    <h3 data-lang="service-2-title">RMC Kreditkarte</h3>
-                    <p data-lang="service-2-desc">Kreditkarte Beschreibung</p>
+                    <h3 data-lang="service-2-title">RMC Credit Card</h3>
+                    <p data-lang="service-2-desc">Prepaid credit card without credit check. Full control over your expenses.</p>
+                    <div class="service-features">
+                        <span>No Credit Check</span>
+                        <span>Prepaid System</span>
+                        <span>Full Control</span>
+                    </div>
                 </div>
                 <div class="service-card">
                     <span class="service-icon">🛣️</span>
-                    <h3 data-lang="service-3-title">Mautlösungen</h3>
-                    <p data-lang="service-3-desc">Maut Beschreibung</p>
+                    <h3 data-lang="service-3-title">Toll Solutions</h3>
+                    <p data-lang="service-3-desc">One provider for 17 countries. Automatic billing, no multiple contracts.</p>
+                    <div class="service-features">
+                        <span>17 Countries</span>
+                        <span>EETS System</span>
+                        <span>One Contract</span>
+                    </div>
                 </div>
                 <div class="service-card">
                     <span class="service-icon">⚡</span>
-                    <h3 data-lang="service-4-title">RMC Ladekarte</h3>
-                    <p data-lang="service-4-desc">Ladekarte Beschreibung</p>
+                    <h3 data-lang="service-4-title">RMC Charging Card</h3>
+                    <p data-lang="service-4-desc">Electromobility across Europe. Available soon.</p>
+                    <div class="coming-soon-badge">Coming Soon</div>
+                </div>
+            </div>
+
+            <div class="target-groups">
+                <h3>The right solution for everyone</h3>
+                <div class="target-grid">
+                    <div class="target-card">
+                        <div class="target-icon">👤</div>
+                        <h4>Private Customers</h4>
+                        <p>Cheap prices, cashless refueling, clear bi-weekly billing</p>
+                        <ul class="target-features">
+                            <li>Daily market prices</li>
+                            <li>Bi-weekly billing</li>
+                            <li>No hidden costs</li>
+                            <li>Online portal access</li>
+                        </ul>
+                    </div>
+
+                    <div class="target-card">
+                        <div class="target-icon">🏢</div>
+                        <h4>Companies</h4>
+                        <p>Fleet management, fixed prices, central billing, tax benefits</p>
+                        <ul class="target-features">
+                            <li>Europe-wide fixed prices</li>
+                            <li>Monthly collective billing</li>
+                            <li>Individual card limits</li>
+                            <li>VAT & fuel tax refunds</li>
+                        </ul>
+                    </div>
+
+                    <div class="target-card">
+                        <div class="target-icon">🚚</div>
+                        <h4>Large Fleets</h4>
+                        <p>Telematics, extended services, all fuels Europe-wide</p>
+                        <ul class="target-features">
+                            <li>KITIN telematics integration</li>
+                            <li>All fuels (Diesel, Petrol, AdBlue, LNG)</li>
+                            <li>Detailed consumption analysis</li>
+                            <li>Transport solutions</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            <div class="countries-section">
+                <h3>Available in 19 countries</h3>
+                <div class="countries-grid">
+                    <div class="country-badge">Austria</div>
+                    <div class="country-badge">Germany</div>
+                    <div class="country-badge">Spain</div>
+                    <div class="country-badge">France</div>
+                    <div class="country-badge">Belgium</div>
+                    <div class="country-badge">Bulgaria</div>
+                    <div class="country-badge">Croatia</div>
+                    <div class="country-badge">Greece</div>
+                    <div class="country-badge">Hungary</div>
+                    <div class="country-badge">Italy</div>
+                    <div class="country-badge">Luxembourg</div>
+                    <div class="country-badge">Netherlands</div>
+                    <div class="country-badge">Poland</div>
+                    <div class="country-badge">Romania</div>
+                    <div class="country-badge">Slovenia</div>
+                    <div class="country-badge">Slovakia</div>
+                    <div class="country-badge">Georgia</div>
+                    <div class="country-badge">Azerbaijan</div>
+                    <div class="country-badge">Kazakhstan</div>
+                </div>
+                <div class="austria-special">
+                    Austria: Guaranteed 1.5 cents savings per liter
                 </div>
             </div>
         </div>
@@ -1094,32 +1179,156 @@
     <!-- Kreditkarte Section -->
     <section id="kreditkarte" class="section">
         <div class="container">
-            <h2 class="section-title" data-lang="creditcard-title">RMC Prepaid Kreditkarte</h2>
-            <p data-lang="creditcard-subtitle">Kreditkarte Infos</p>
+            <h2 class="section-title">RMC Prepaid Credit Card</h2>
+            <p class="section-subtitle">Maximum flexibility on the road – without credit check</p>
+            
+            <div class="usage-section">
+                <h3>Perfect for travel</h3>
+                <div class="usage-grid">
+                    <div class="usage-card">
+                        <div class="usage-icon">🔧</div>
+                        <h4>Workshop costs & repairs</h4>
+                        <p>Pay for spontaneous repairs flexibly, even abroad</p>
+                    </div>
+                    
+                    <div class="usage-card">
+                        <div class="usage-icon">🏨</div>
+                        <h4>Hotels & accommodations</h4>
+                        <p>Many hotels require a credit card when booking or checking in</p>
+                    </div>
+                    
+                    <div class="usage-card">
+                        <div class="usage-icon">🍽️</div>
+                        <h4>Restaurants & food</h4>
+                        <p>Pay conveniently in restaurants, supermarkets or service stations</p>
+                    </div>
+                    
+                    <div class="usage-card">
+                        <div class="usage-icon">🅿️</div>
+                        <h4>Parking fees & fines</h4>
+                        <p>Pay parking tickets and fines directly at the machine</p>
+                    </div>
+                    
+                    <div class="usage-card">
+                        <div class="usage-icon">🎫</div>
+                        <h4>Reservations & online bookings</h4>
+                        <p>Book ferries, toll routes or parking spaces securely in advance</p>
+                    </div>
+                    
+                    <div class="usage-card">
+                        <div class="usage-icon">🚨</div>
+                        <h4>Emergencies & spontaneous expenses</h4>
+                        <p>Financial reserve for unexpected situations</p>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="benefits-section">
+                <h3>Your benefits</h3>
+                <div class="benefits-grid">
+                    <div class="benefit-card">
+                        <h4>Without credit check</h4>
+                        <p>Only loaded credit can be used – no debt possible</p>
+                    </div>
+                    
+                    <div class="benefit-card">
+                        <h4>Maximum cost control</h4>
+                        <p>You can only spend available credit</p>
+                    </div>
+                    
+                    <div class="benefit-card">
+                        <h4>Full transparency</h4>
+                        <p>All payments visible online in the portal at any time</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </section>
 
     <!-- Maut Section -->
     <section id="maut" class="section maut-bg">
         <div class="container">
-            <h2 class="section-title" data-lang="toll-title">Mautlösungen</h2>
-            <p data-lang="toll-subtitle">Maut Infos</p>
+            <h2 class="section-title">Toll Solutions for Europe</h2>
+            <p class="section-subtitle">One provider for 17 countries – simple, reliable, transparent</p>
+            
+            <div class="advantages-section">
+                <h3>Your advantages</h3>
+                <div class="advantages-grid">
+                    <div class="advantage-card">
+                        <h4>One provider for all toll systems</h4>
+                        <p>No need for multiple contracts anymore – everything from one source</p>
+                    </div>
+                    
+                    <div class="advantage-card">
+                        <h4>EETS integration</h4>
+                        <p>New countries can be added in minutes</p>
+                    </div>
+                    
+                    <div class="advantage-card">
+                        <h4>Combined billing</h4>
+                        <p>Toll and fuel in one invoice for maximum efficiency</p>
+                    </div>
+                    
+                    <div class="advantage-card">
+                        <h4>Daily overview</h4>
+                        <p>All toll fees transparent in the RMC Service portal</p>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="countries-section">
+                <h3>Available in 17 countries</h3>
+                <div class="countries-grid">
+                    <div class="country-badge">Austria</div>
+                    <div class="country-badge">Germany</div>
+                    <div class="country-badge">Belgium</div>
+                    <div class="country-badge">France</div>
+                    <div class="country-badge">Spain</div>
+                    <div class="country-badge">Portugal</div>
+                    <div class="country-badge">Italy</div>
+                    <div class="country-badge">Hungary</div>
+                    <div class="country-badge">Slovakia</div>
+                    <div class="country-badge">Slovenia</div>
+                    <div class="country-badge">Croatia</div>
+                    <div class="country-badge">Bulgaria</div>
+                    <div class="country-badge">Sweden</div>
+                    <div class="country-badge">Norway</div>
+                    <div class="country-badge">Denmark</div>
+                    <div class="country-badge">Poland</div>
+                    <div class="country-badge">Switzerland</div>
+                </div>
+            </div>
+            
+            <div class="tunnel-section">
+                <div class="tunnel-card">
+                    <h4>Tunnel service included</h4>
+                    <p>Automatic billing of tunnel fees without waiting times – all fees are automatically recorded and billed transparently</p>
+                </div>
+            </div>
         </div>
     </section>
 
     <!-- Ladekarte Section -->
     <section id="ladekarte" class="section">
         <div class="container">
-            <h2 class="section-title" data-lang="charging-title">RMC Ladekarte</h2>
-            <p data-lang="charging-desc">Ladekarte Infos</p>
+            <h2 class="section-title">RMC Charging Card</h2>
+            <p class="section-subtitle">The key to electromobility – available soon</p>
+            
+            <div class="charging-content">
+                <p>Easy charging at numerous charging stations across Europe. Cashless, transparent, future-proof.</p>
+                <p>The RMC Charging Card will be available soon and enables electric vehicles to be charged conveniently and easily at a growing network of charging stations.</p>
+            </div>
         </div>
     </section>
 
     <!-- Kontakt Section -->
     <section id="kontakt" class="section kontakt">
         <div class="container">
-            <h2 class="section-title" data-lang="contact-title">LKW-Tankkarte beantragen</h2>
-            <p style="text-align: center; margin-bottom: 3rem; font-size: 1.1rem;" data-lang="contact-subtitle">Sie möchten eine Dieselkarte für Ihre LKW-Flotte beantragen?<br>Kontaktieren Sie uns – wir beraten Sie persönlich und kostenlos!</p>
+            <h2 class="section-title" data-lang="contact-title">Apply for truck fuel card</h2>
+            <p style="text-align: center; margin-bottom: 3rem; font-size: 1.1rem;" data-lang="contact-subtitle">
+                Would you like to apply for a fuel card for your truck fleet?<br>
+                Contact us – we advise you personally and free of charge!
+            </p>
             
             <div class="kontakt-content">
                 <form class="contact-form">
@@ -1148,11 +1357,11 @@
                         <textarea id="nachricht" name="nachricht" rows="4"></textarea>
                     </div>
 
-                    <button type="submit" class="btn" data-lang="form-submit">Jetzt kostenlos beraten lassen</button>
+                    <button type="submit" class="btn" data-lang="form-submit">Get free consultation now</button>
                 </form>
 
                 <div class="contact-info">
-                    <h3 data-lang="contact-direct">Direkter Kontakt</h3>
+                    <h3 data-lang="contact-direct">Direct contact</h3>
                     <div class="contact-item">
                         <span class="contact-item-icon">📞</span>
                         <a href="tel:+905530540989">+90 5530540989</a>
@@ -1162,8 +1371,8 @@
                         <a href="mailto:o.gokceviran@rmc-service.com">o.gokceviran@rmc-service.com</a>
                     </div>
                     <p style="margin-top: 2rem; color: var(--medium-gray);" data-lang="contact-description">
-                        Unser Team steht Ihnen für alle Fragen rund um LKW-Tankkarten zur Verfügung. 
-                        Wir beraten Sie gerne unverbindlich und finden die beste Lösung für Ihr Unternehmen.
+                        Our team is available for all questions regarding truck fuel cards. 
+                        We are happy to advise you without obligation and find the best solution for your company.
                     </p>
                 </div>
             </div>
@@ -1214,18 +1423,87 @@
                     Sie erhalten eine übersichtliche Monatsabrechnung mit allen Tankvorgängen. Die Zahlung erfolgt bequem per Lastschrift oder Überweisung.
                 </div>
             </div>
+
+            <div class="faq-item">
+                <button class="faq-question" onclick="toggleFaq(this)">
+                    <span>How does the prepaid credit card work?</span>
+                    <span class="faq-icon">+</span>
+                </button>
+                <div class="faq-answer">
+                    You load credit onto the card and can only spend what you have loaded. No credit check required.
+                </div>
+            </div>
+
+            <div class="faq-item">
+                <button class="faq-question" onclick="toggleFaq(this)">
+                    <span>In which countries does the toll solution work?</span>
+                    <span class="faq-icon">+</span>
+                </button>
+                <div class="faq-answer">
+                    Currently in 17 European countries, from Austria and Germany to Sweden and Croatia.
+                </div>
+            </div>
+
+            <div class="faq-item">
+                <button class="faq-question" onclick="toggleFaq(this)">
+                    <span>What is the difference between private and business customers?</span>
+                    <span class="faq-icon">+</span>
+                </button>
+                <div class="faq-answer">
+                    Private customers receive bi-weekly billing, business customers monthly billing with fixed prices and extended services.
+                </div>
+            </div>
+
+            <div class="faq-item">
+                <button class="faq-question" onclick="toggleFaq(this)">
+                    <span>Does the fuel card work in the UK after Brexit?</span>
+                    <span class="faq-icon">+</span>
+                </button>
+                <div class="faq-answer">
+                    Currently, our services focus on EU countries and selected partners. For UK availability, please contact our customer service.
+                </div>
+            </div>
+
+            <div class="faq-item">
+                <button class="faq-question" onclick="toggleFaq(this)">
+                    <span>What is KITIN telematics and how does it work?</span>
+                    <span class="faq-icon">+</span>
+                </button>
+                <div class="faq-answer">
+                    KITIN is our advanced fleet management system that provides real-time tracking, route optimization, and detailed analytics for your vehicles across Europe.
+                </div>
+            </div>
         </div>
     </section>
 
     <!-- Zusatzservices Section -->
     <section id="zusatzservices" class="section additional-services">
         <div class="container">
-            <h2 class="section-title" data-lang="additional-title">Zusatzservices</h2>
+            <h2 class="section-title">Additional Services</h2>
             <div class="additional-grid">
                 <div class="service-card">
-                    <span class="service-icon">📊</span>
-                    <h3 data-lang="additional-vat-title">MwSt-Rückerstattung</h3>
-                    <p data-lang="additional-vat-desc">Steuervorteile nutzen</p>
+                    <h3>VAT Refund</h3>
+                    <p>Recover VAT from European countries. Complete processing through our experienced partners.</p>
+                </div>
+                
+                <div class="service-card">
+                    <h3>Fuel Tax Refund</h3>
+                    <p>Utilize fuel tax savings potential. Possible in many EU countries.</p>
+                </div>
+                
+                <div class="service-card">
+                    <h3>Prepay Credit Account</h3>
+                    <p>Full expense control without credit check. Maximum transparency and planning security.</p>
+                </div>
+                
+                <div class="service-card">
+                    <h3>24/7 Breakdown Service</h3>
+                    <p>Help around the clock across Europe in emergencies. Hotline: +43 662 856 85990</p>
+                </div>
+                
+                <div class="service-card">
+                    <h3>KITIN Telematics</h3>
+                    <p>Next generation fleet management. Real-time tracking and optimization.</p>
                 </div>
             </div>
         </div>
@@ -1238,7 +1516,7 @@
                 <div class="footer-section">
                     <h4>Özkan Gökceviran</h4>
                     <p data-lang="footer-subtitle">A partner of RMC Service GmbH</p>
-                    <p data-lang="footer-description">Ihr Partner für LKW-Tankkarten in Europa</p>
+                    <p data-lang="footer-description">Your partner for European mobility solutions</p>
                 </div>
                 
                 <div class="footer-section">
@@ -1345,13 +1623,13 @@
                 'hero-cta': 'Request fuel card now',
                 'services-title': 'Our Mobility Solutions',
                 'service-1-title': 'RMC Fuel Card',
-                'service-1-desc': 'Refuel cheaply across Europe',
+                'service-1-desc': 'Refuel cheaply across Europe at over 10,000 gas stations. No fees, attractive prices.',
                 'service-2-title': 'RMC Credit Card',
-                'service-2-desc': 'Prepaid without credit check',
+                'service-2-desc': 'Prepaid credit card without credit check. Full control over your expenses.',
                 'service-3-title': 'Toll Solutions',
-                'service-3-desc': 'One provider for 17 countries',
+                'service-3-desc': 'One provider for 17 countries. Automatic billing, no multiple contracts.',
                 'service-4-title': 'RMC Charging Card',
-                'service-4-desc': 'Coming soon',
+                'service-4-desc': 'Electromobility across Europe. Available soon.',
                 'card-text-en': 'FUEL CARD EUROPE',
                 'benefits-title': 'Why our fuel card?',
                 'benefit-1-title': 'Europe-wide acceptance',


### PR DESCRIPTION
## Summary
- update meta title and description for RMC services
- rewrite hero section with mobility card details
- expand services overview with detailed cards
- add fuel card target groups and country coverage
- rebuild credit card, toll and charging card sections
- extend additional services and FAQ items
- adjust contact section and footer text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6876c62c1394832398a8ca5442b3aa7d