### PR TITLE
Fix RMC logo style and confirm image paths

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -252,7 +252,6 @@
             height: 30px;
             background: var(--primary-green);
             border-radius: 4px;
-            background-image: url('../images/rmclogo.png');
             background-size: contain;
             background-repeat: no-repeat;
             background-position: center;
@@ -1098,7 +1097,7 @@
     <section id="start" class="hero">
         <!-- Tankkarte - außerhalb der Parallax-Animation -->
         <div class="fuel-card">
-            <div class="rmc-logo"></div>
+            <div class="rmc-logo" style="background-image: url('../images/rmclogo.png');"></div>
             <div class="wave"></div>
             <div class="wave"></div>
             <div class="wave"></div>

--- a/en/index.html
+++ b/en/index.html
@@ -252,7 +252,6 @@
             height: 30px;
             background: var(--primary-green);
             border-radius: 4px;
-            background-image: url('../images/rmclogo.png');
             background-size: contain;
             background-repeat: no-repeat;
             background-position: center;
@@ -963,7 +962,7 @@
     <section id="start" class="hero">
         <!-- Tankkarte - außerhalb der Parallax-Animation -->
         <div class="fuel-card">
-            <div class="rmc-logo"></div>
+            <div class="rmc-logo" style="background-image: url('../images/rmclogo.png');"></div>
             <div class="wave"></div>
             <div class="wave"></div>
             <div class="wave"></div>

--- a/index.html
+++ b/index.html
@@ -252,7 +252,6 @@
             height: 30px;
             background: var(--primary-green);
             border-radius: 4px;
-            background-image: url('images/rmclogo.png');
             background-size: contain;
             background-repeat: no-repeat;
             background-position: center;
@@ -1122,7 +1121,7 @@
     <section id="start" class="hero">
         <!-- Tankkarte - außerhalb der Parallax-Animation -->
         <div class="fuel-card">
-            <div class="rmc-logo"></div>
+            <div class="rmc-logo" style="background-image: url('images/rmclogo.png');"></div>
             <div class="wave"></div>
             <div class="wave"></div>
             <div class="wave"></div>


### PR DESCRIPTION
## Summary
- remove `background-image` CSS from `.rmc-logo`
- specify RMC logo background in HTML with language‑specific paths

## Testing
- `tidy -q de/index.html`
- `tidy -q en/index.html`
- `tidy -q index.html`


------
https://chatgpt.com/codex/tasks/task_e_6876cb23e5d08323b96a8b02c2feeb4a