### PR TITLE
Expand README and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Einfach Starten
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-#tankkarte
+# Tankkarte
+
+A static multilingual website for the **Filo.cards** fuel card service. The project delivers
+content in German and Turkish using a small JavaScript based translation system. The site is
+primarily HTML, CSS and vanilla JavaScript so no heavy build process is required.
+
+## Project Structure
+
+```
+css/            Stylesheets
+js/             JavaScript for translation and page logic
+images/         Graphics used by the site
+_en_backup/     Previous English version kept for reference
+tr/             Turkish version of the landing page
+```
+
+All text translations live in `data/translations.json` and are loaded at runtime.
+
+## Building
+
+Because the project is purely static, there is no traditional build step. If you would like to
+work on the site locally, simply clone the repository and open `index.html` in your browser.
+Optionally you can use any static HTTP server to view the site, for example:
+
+```bash
+npx http-server
+```
+
+This command serves the directory on a local port so you can test the translation loader.
+
+## Deployment
+
+Deployment consists of copying the repository contents to your hosting provider. Any static file
+host such as GitHub Pages, Netlify or a traditional web server will work. Make sure the folder
+structure is preserved and that `index.html` is served from the root of your domain.
+
+## License
+
+This project is released under the [MIT License](LICENSE). You are free to use, modify and
+redistribute it under the terms of that license.


### PR DESCRIPTION
## Summary
- detail project structure, build and deployment info in README
- include MIT license for the site

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68775f9d66d883238e886cb423cd1771