### PR TITLE
Fix image paths and translations

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -432,7 +432,21 @@
         }
 
         .benefit-card .benefit-icon {
-            display: none !important;
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            width: 40px;
+            height: 40px;
+            opacity: 0.8;
+            z-index: 3;
+            border-radius: 8px;
+            object-fit: cover;
+            transition: var(--transition);
+        }
+
+        .benefit-card:hover .benefit-icon {
+            opacity: 1;
+            transform: scale(1.1);
         }
 
         .benefit-card h3 {

--- a/data/translations.json
+++ b/data/translations.json
@@ -8,6 +8,7 @@
   "translations": {
     "de": {
       "page": {
+        "lang": "de",
         "title": "Europäische Mobilitätslösungen | filo.cards",
         "description": "Tankkarte, Maut & Kreditkarte für Europa. Bargeldlos tanken, transparent abrechnen. Partner von RMC Service GmbH.",
         "keywords": "tankkarte europa, lkw tankkarte, mautlösungen, prepaid kreditkarte, flottenmanagement, RMC service, europäische mobilität"
@@ -305,6 +306,7 @@
     },
     "en": {
       "page": {
+        "lang": "en",
         "title": "European Mobility Solutions | filo.cards",
         "description": "Cashless fuel across Europe with our fuel card. Toll solutions for 17 countries. Prepaid credit card without credit check. All from one provider.",
         "keywords": "fuel card europe, truck fuel card, toll solutions, prepaid credit card, fleet management, RMC service, european mobility"
@@ -610,6 +612,7 @@
     },
     "tr": {
       "page": {
+        "lang": "tr",
         "title": "Avrupa Mobilite Çözümleri | filo.cards",
         "description": "Yakıt kartımızla Avrupa genelinde nakitsiz yakıt. 17 ülke için geçiş ücreti çözümleri. Kredi kontrolü olmadan ön ödemeli kredi kartı. Tek sağlayıcıdan hepsi.",
         "keywords": "avrupa yakıt kartı, kamyon yakıt kartı, geçiş ücreti çözümleri, ön ödemeli kredi kartı, filo yönetimi, RMC servis, avrupa mobilite, türkiye nakliye"

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="description" content="" data-translate="page.description">
     <link rel="canonical" href="https://www.filo.cards/">
     <title data-translate="page.title">Loading...</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚛</text></svg>">
     
     <!-- JSON und JavaScript laden -->
     <script src="js/translations.js" defer></script>
@@ -138,22 +139,27 @@
                 <!-- Benefits Grid -->
                 <div class="benefits-grid">
                     <div class="benefit-card scroll-reveal" style="background-image: url('images/europa-karte.png');">
+                        <img src="images/europa-karte.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit1.title">
                         <h3 data-translate="fuelcard.benefit1.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit1.description">Loading...</p>
                     </div>
                     <div class="benefit-card scroll-reveal" style="background-image: url('images/diesel-preise.png');">
+                        <img src="images/diesel-preise.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit2.title">
                         <h3 data-translate="fuelcard.benefit2.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit2.description">Loading...</p>
                     </div>
                     <div class="benefit-card scroll-reveal" style="background-image: url('images/sicherheit.png');">
+                        <img src="images/sicherheit.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit3.title">
                         <h3 data-translate="fuelcard.benefit3.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit3.description">Loading...</p>
                     </div>
                     <div class="benefit-card scroll-reveal" style="background-image: url('images/abrechnung.png');">
+                        <img src="images/abrechnung.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit4.title">
                         <h3 data-translate="fuelcard.benefit4.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit4.description">Loading...</p>
                     </div>
                     <div class="benefit-card scroll-reveal" style="background-image: url('images/service.png');">
+                        <img src="images/service.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit5.title">
                         <h3 data-translate="fuelcard.benefit5.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit5.description">Loading...</p>
                     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -80,11 +80,13 @@ function translateAllElements() {
         const translation = window.translationLoader.getTranslation(key);
 
         if (translation && translation !== key) {
-            element.textContent = translation;
-
-            // Handle HTML content for subtitles with <br>
-            if (key.includes('subtitle') && translation.includes('<br>')) {
-                element.innerHTML = translation;
+            if (element.tagName === 'IMG') {
+                element.setAttribute('alt', translation);
+            } else {
+                element.textContent = translation;
+                if (key.includes('subtitle') && translation.includes('<br>')) {
+                    element.innerHTML = translation;
+                }
             }
         }
     });


### PR DESCRIPTION
## Summary
- include SVG favicon
- show benefit card icons with alt-text translation
- style benefit card icons instead of hiding them
- add `page.lang` to translations

## Testing
- `jq . data/translations.json >/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_687760a7b9d083238e5081f3db557729