### PR TITLE
Fix translation meta update and FAQ errors

### DIFF
--- a/data/translations.json
+++ b/data/translations.json
@@ -8,7 +8,6 @@
   "translations": {
     "de": {
       "page": {
-        "lang": "de",
         "title": "Europäische Mobilitätslösungen | filo.cards",
         "description": "Tankkarte, Maut & Kreditkarte für Europa. Bargeldlos tanken, transparent abrechnen. Partner von RMC Service GmbH.",
         "keywords": "tankkarte europa, lkw tankkarte, mautlösungen, prepaid kreditkarte, flottenmanagement, RMC service, europäische mobilität"
@@ -306,7 +305,6 @@
     },
     "en": {
       "page": {
-        "lang": "en",
         "title": "European Mobility Solutions | filo.cards",
         "description": "Cashless fuel across Europe with our fuel card. Toll solutions for 17 countries. Prepaid credit card without credit check. All from one provider.",
         "keywords": "fuel card europe, truck fuel card, toll solutions, prepaid credit card, fleet management, RMC service, european mobility"
@@ -612,7 +610,6 @@
     },
     "tr": {
       "page": {
-        "lang": "tr",
         "title": "Avrupa Mobilite Çözümleri | filo.cards",
         "description": "Yakıt kartımızla Avrupa genelinde nakitsiz yakıt. 17 ülke için geçiş ücreti çözümleri. Kredi kontrolü olmadan ön ödemeli kredi kartı. Tek sağlayıcıdan hepsi.",
         "keywords": "avrupa yakıt kartı, kamyon yakıt kartı, geçiş ücreti çözümleri, ön ödemeli kredi kartı, filo yönetimi, RMC servis, avrupa mobilite, türkiye nakliye"

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de" data-translate="page.lang">
+<html lang="de">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -138,27 +138,27 @@
                 
                 <!-- Benefits Grid -->
                 <div class="benefits-grid">
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/europa-karte.png');">
+                    <div class="benefit-card scroll-reveal">
                         <img src="images/europa-karte.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit1.title">
                         <h3 data-translate="fuelcard.benefit1.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit1.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/diesel-preise.png');">
+                    <div class="benefit-card scroll-reveal">
                         <img src="images/diesel-preise.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit2.title">
                         <h3 data-translate="fuelcard.benefit2.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit2.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/sicherheit.png');">
+                    <div class="benefit-card scroll-reveal">
                         <img src="images/sicherheit.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit3.title">
                         <h3 data-translate="fuelcard.benefit3.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit3.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/abrechnung.png');">
+                    <div class="benefit-card scroll-reveal">
                         <img src="images/abrechnung.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit4.title">
                         <h3 data-translate="fuelcard.benefit4.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit4.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/service.png');">
+                    <div class="benefit-card scroll-reveal">
                         <img src="images/service.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit5.title">
                         <h3 data-translate="fuelcard.benefit5.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit5.description">Loading...</p>

--- a/js/main.js
+++ b/js/main.js
@@ -66,6 +66,9 @@ function updatePageMeta(lang) {
 
     document.title = title;
 
+    // Update HTML lang attribute manually
+    document.documentElement.lang = lang;
+
     // Update meta description
     const metaDesc = document.querySelector('meta[name="description"]');
     if (metaDesc) {
@@ -145,6 +148,10 @@ function updateFuelCardText(lang) {
 function handleSpecialTranslations(lang) {
     // Add language-specific FAQs
     const languageSpecificFaqs = document.getElementById('language-specific-faqs');
+    if (!languageSpecificFaqs) {
+        console.warn('language-specific-faqs element not found');
+        return;
+    }
     languageSpecificFaqs.innerHTML = '';
 
     if (lang === 'en') {


### PR DESCRIPTION
## Summary
- remove `data-translate` from the `<html>` element
- drop background-image attributes from benefit cards
- update `updatePageMeta()` to also change the document language
- guard against missing language-specific FAQ container
- remove unused `page.lang` translations

## Testing
- `python3 -m json.tool data/translations.json`

------
https://chatgpt.com/codex/tasks/task_e_687763ad57c48323bb25246b73f19b14