### PR TITLE
Fix gradient overlay on benefit cards

### DIFF
--- a/_en_backup/index.html
+++ b/_en_backup/index.html
@@ -428,9 +428,6 @@
             display: flex;
             flex-direction: column;
             justify-content: center;
-            background-size: cover;
-            background-position: center;
-            background-repeat: no-repeat;
         }
 
         .benefit-card::before {
@@ -440,11 +437,14 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: linear-gradient(135deg, 
-                rgba(27, 94, 32, 0.7) 0%, 
-                rgba(76, 175, 80, 0.6) 50%, 
+            background: linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
                 rgba(255, 214, 0, 0.3) 100%
             );
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
             z-index: 1;
         }
 
@@ -480,6 +480,46 @@
 
         .benefit-card p {
             color: rgba(255, 255, 255, 0.9);
+        }
+
+        .benefit-card[data-bg="europa"]::before {
+            background-image: url('../images/europa-karte.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="diesel"]::before {
+            background-image: url('../images/diesel-preise.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="sicherheit"]::before {
+            background-image: url('../images/sicherheit.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="abrechnung"]::before {
+            background-image: url('../images/abrechnung.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="service"]::before {
+            background-image: url('../images/service.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
         }
 
         /* Funktion Section */
@@ -1199,31 +1239,31 @@
             <h2 class="section-title" data-lang="benefits-title">Warum unsere Tankkarte?</h2>
             
             <div class="benefits-grid">
-                <div class="benefit-card scroll-reveal" style="background-image: url('../images/europa-karte.png');">
+                <div class="benefit-card scroll-reveal" data-bg="europa">
                     <img src='../images/europa-karte.png' class='benefit-icon' loading='lazy' alt='Europe-wide acceptance' data-lang-alt='benefit-1-title'>
                     <h3 data-lang="benefit-1-title">Europaweite Akzeptanz</h3>
                     <p data-lang="benefit-1-text">Über 10.000 Tankstellen in ganz Europa, inklusive freier Marken für maximale Flexibilität.</p>
                 </div>
 
-                <div class="benefit-card scroll-reveal" style="background-image: url('../images/diesel-preise.png');">
+                <div class="benefit-card scroll-reveal" data-bg="diesel">
                     <img src='../images/diesel-preise.png' class='benefit-icon' loading='lazy' alt='Attractive diesel prices' data-lang-alt='benefit-2-title'>
                     <h3 data-lang="benefit-2-title">Attraktive Dieselpreise</h3>
                     <p data-lang="benefit-2-text">Profitieren Sie von exklusiven Flottenrabatten und günstigen Dieselpreisen für Ihr Unternehmen.</p>
                 </div>
 
-                <div class="benefit-card scroll-reveal" style="background-image: url('../images/sicherheit.png');">
+                <div class="benefit-card scroll-reveal" data-bg="sicherheit">
                     <img src='../images/sicherheit.png' class='benefit-icon' loading='lazy' alt='Cashless and secure' data-lang-alt='benefit-3-title'>
                     <h3 data-lang="benefit-3-title">Bargeldlos und sicher</h3>
                     <p data-lang="benefit-3-text">PIN-Schutz und zentrale Abrechnung sorgen für maximale Sicherheit und Kontrolle.</p>
                 </div>
 
-                <div class="benefit-card scroll-reveal" style="background-image: url('../images/abrechnung.png');">
+                <div class="benefit-card scroll-reveal" data-bg="abrechnung">
                     <img src='../images/abrechnung.png' class='benefit-icon' loading='lazy' alt='No paperwork' data-lang-alt='benefit-4-title'>
                     <h3 data-lang="benefit-4-title">Kein Papierkram</h3>
                     <p data-lang="benefit-4-text">Einfache Monatsabrechnung mit transparenter Aufstellung aller Tankvorgänge.</p>
                 </div>
 
-                <div class="benefit-card scroll-reveal" style="background-image: url('../images/service.png');">
+                <div class="benefit-card scroll-reveal" data-bg="service">
                     <img src='../images/service.png' class='benefit-icon' loading='lazy' alt='Personal service' data-lang-alt='benefit-5-title'>
                     <h3 data-lang="benefit-5-title">Persönlicher Service</h3>
                     <p data-lang="benefit-5-text">Direkte Ansprechpartner und persönliche Betreuung, auch für Einzelunternehmer.</p>

--- a/css/styles.css
+++ b/css/styles.css
@@ -392,9 +392,6 @@
             display: flex;
             flex-direction: column;
             justify-content: center;
-            background-size: cover;
-            background-position: center;
-            background-repeat: no-repeat;
         }
 
         .benefit-card::before {
@@ -404,13 +401,16 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: linear-gradient(135deg, 
-                rgba(27, 94, 32, 0.7) 0%, 
-                rgba(76, 175, 80, 0.6) 50%, 
+            background: linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
                 rgba(255, 214, 0, 0.3) 100%
             );
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
             z-index: 1;
-        }
+       }
 
         .benefit-card:hover::before {
             background: linear-gradient(135deg, 
@@ -458,6 +458,46 @@
 
         .benefit-card p {
             color: rgba(255, 255, 255, 0.9);
+        }
+
+        .benefit-card[data-bg="europa"]::before {
+            background-image: url('images/europa-karte.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="diesel"]::before {
+            background-image: url('images/diesel-preise.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="sicherheit"]::before {
+            background-image: url('images/sicherheit.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="abrechnung"]::before {
+            background-image: url('images/abrechnung.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="service"]::before {
+            background-image: url('images/service.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
         }
 
         /* Funktion Section */

--- a/index.html
+++ b/index.html
@@ -138,27 +138,27 @@
                 
                 <!-- Benefits Grid -->
                 <div class="benefits-grid">
-                    <div class="benefit-card scroll-reveal">
+                    <div class="benefit-card scroll-reveal" data-bg="europa">
                         <img src="images/europa-karte.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit1.title">
                         <h3 data-translate="fuelcard.benefit1.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit1.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal">
+                    <div class="benefit-card scroll-reveal" data-bg="diesel">
                         <img src="images/diesel-preise.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit2.title">
                         <h3 data-translate="fuelcard.benefit2.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit2.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal">
+                    <div class="benefit-card scroll-reveal" data-bg="sicherheit">
                         <img src="images/sicherheit.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit3.title">
                         <h3 data-translate="fuelcard.benefit3.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit3.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal">
+                    <div class="benefit-card scroll-reveal" data-bg="abrechnung">
                         <img src="images/abrechnung.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit4.title">
                         <h3 data-translate="fuelcard.benefit4.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit4.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal">
+                    <div class="benefit-card scroll-reveal" data-bg="service">
                         <img src="images/service.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit5.title">
                         <h3 data-translate="fuelcard.benefit5.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit5.description">Loading...</p>

--- a/tr/index.html
+++ b/tr/index.html
@@ -427,9 +427,6 @@
             display: flex;
             flex-direction: column;
             justify-content: center;
-            background-size: cover;
-            background-position: center;
-            background-repeat: no-repeat;
         }
 
         .benefit-card::before {
@@ -439,11 +436,14 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: linear-gradient(135deg, 
-                rgba(27, 94, 32, 0.7) 0%, 
-                rgba(76, 175, 80, 0.6) 50%, 
+            background: linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
                 rgba(255, 214, 0, 0.3) 100%
             );
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
             z-index: 1;
         }
 
@@ -479,6 +479,46 @@
 
         .benefit-card p {
             color: rgba(255, 255, 255, 0.9);
+        }
+
+        .benefit-card[data-bg="europa"]::before {
+            background-image: url('../images/europa-karte.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="diesel"]::before {
+            background-image: url('../images/diesel-preise.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="sicherheit"]::before {
+            background-image: url('../images/sicherheit.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="abrechnung"]::before {
+            background-image: url('../images/abrechnung.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
+        }
+
+        .benefit-card[data-bg="service"]::before {
+            background-image: url('../images/service.png'), linear-gradient(135deg,
+                rgba(27, 94, 32, 0.7) 0%,
+                rgba(76, 175, 80, 0.6) 50%,
+                rgba(255, 214, 0, 0.3) 100%
+            );
         }
 
         /* Funktion Section */
@@ -1315,27 +1355,27 @@
 <div class="container">
 <h2 class="section-title">Neden bizim yakıt kartımız?</h2>
 <div class="benefits-grid">
-<div class="benefit-card scroll-reveal" style="background-image: url('../images/europa-karte.png');">
+<div class="benefit-card scroll-reveal" data-bg="europa">
 <img alt="Avrupa genelinde kabul" class="benefit-icon" loading="lazy" src="../images/europa-karte.png"/>
 <h3>Avrupa genelinde kabul</h3>
 <p>Avrupa genelinde 10.000'den fazla benzin istasyonu, maksimum esneklik için bağımsız markalar dahil.</p>
 </div>
-<div class="benefit-card scroll-reveal" style="background-image: url('../images/diesel-preise.png');">
+<div class="benefit-card scroll-reveal" data-bg="diesel">
 <img alt='Cazip mazot fiyatları' class='benefit-icon' loading='lazy' src='../images/diesel-preise.png'/>
 <h3>Cazip mazot fiyatları</h3>
 <p>Şirketiniz için özel filo indirimlerinden ve uygun mazot fiyatlarından yararlanın.</p>
 </div>
-<div class="benefit-card scroll-reveal" style="background-image: url('../images/sicherheit.png');">
+<div class="benefit-card scroll-reveal" data-bg="sicherheit">
 <img alt="Nakitsiz ve güvenli" class="benefit-icon" loading="lazy" src="../images/sicherheit.png"/>
 <h3>Nakitsiz ve güvenli</h3>
 <p>PIN koruması ve merkezi faturalandırma maksimum güvenlik ve kontrol sağlar.</p>
 </div>
-<div class="benefit-card scroll-reveal" style="background-image: url('../images/abrechnung.png');">
+<div class="benefit-card scroll-reveal" data-bg="abrechnung">
 <img alt="Evrak işi yok" class="benefit-icon" loading="lazy" src="../images/abrechnung.png"/>
 <h3>Evrak işi yok</h3>
 <p>Tüm yakıt işlemlerinin şeffaf listesiyle basit aylık faturalandırma.</p>
 </div>
-<div class="benefit-card scroll-reveal" style="background-image: url('../images/service.png');">
+<div class="benefit-card scroll-reveal" data-bg="service">
 <img alt="Kişisel hizmet" class="benefit-icon" loading="lazy" src="../images/service.png"/>
 <h3>Kişisel hizmet</h3>
 <p>Bireysel girişimciler için de doğrudan iletişim ve kişisel destek.</p>


### PR DESCRIPTION
## Summary
- keep background image and gradient on benefit cards
- configure cards via `data-bg` attributes
- update translated pages to use the new approach

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877664ebd4c8323b63c0e1b6f2d41e3