### PR TITLE
Update benefit card backgrounds

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -381,6 +381,9 @@
 
         .benefit-card {
             background: var(--white);
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
             padding: 2.5rem;
             border-radius: var(--border-radius);
             box-shadow: var(--shadow);
@@ -402,21 +405,18 @@
             right: 0;
             bottom: 0;
             background: linear-gradient(135deg,
-                rgba(27, 94, 32, 0.7) 0%,
-                rgba(76, 175, 80, 0.6) 50%,
-                rgba(255, 214, 0, 0.3) 100%
+                rgba(27, 94, 32, 0.4) 0%,
+                rgba(76, 175, 80, 0.3) 50%,
+                rgba(255, 214, 0, 0.2) 100%
             );
-            background-size: cover;
-            background-position: center;
-            background-repeat: no-repeat;
             z-index: 1;
        }
 
         .benefit-card:hover::before {
-            background: linear-gradient(135deg, 
-                rgba(27, 94, 32, 0.8) 0%, 
-                rgba(76, 175, 80, 0.7) 50%, 
-                rgba(255, 214, 0, 0.4) 100%
+            background: linear-gradient(135deg,
+                rgba(27, 94, 32, 0.6) 0%,
+                rgba(76, 175, 80, 0.5) 50%,
+                rgba(255, 214, 0, 0.3) 100%
             );
         }
 
@@ -460,45 +460,6 @@
             color: rgba(255, 255, 255, 0.9);
         }
 
-        .benefit-card[data-bg="europa"]::before {
-            background-image: url('images/europa-karte.png'), linear-gradient(135deg,
-                rgba(27, 94, 32, 0.7) 0%,
-                rgba(76, 175, 80, 0.6) 50%,
-                rgba(255, 214, 0, 0.3) 100%
-            );
-        }
-
-        .benefit-card[data-bg="diesel"]::before {
-            background-image: url('images/diesel-preise.png'), linear-gradient(135deg,
-                rgba(27, 94, 32, 0.7) 0%,
-                rgba(76, 175, 80, 0.6) 50%,
-                rgba(255, 214, 0, 0.3) 100%
-            );
-        }
-
-        .benefit-card[data-bg="sicherheit"]::before {
-            background-image: url('images/sicherheit.png'), linear-gradient(135deg,
-                rgba(27, 94, 32, 0.7) 0%,
-                rgba(76, 175, 80, 0.6) 50%,
-                rgba(255, 214, 0, 0.3) 100%
-            );
-        }
-
-        .benefit-card[data-bg="abrechnung"]::before {
-            background-image: url('images/abrechnung.png'), linear-gradient(135deg,
-                rgba(27, 94, 32, 0.7) 0%,
-                rgba(76, 175, 80, 0.6) 50%,
-                rgba(255, 214, 0, 0.3) 100%
-            );
-        }
-
-        .benefit-card[data-bg="service"]::before {
-            background-image: url('images/service.png'), linear-gradient(135deg,
-                rgba(27, 94, 32, 0.7) 0%,
-                rgba(76, 175, 80, 0.6) 50%,
-                rgba(255, 214, 0, 0.3) 100%
-            );
-        }
 
         /* Funktion Section */
         .steps-container {

--- a/index.html
+++ b/index.html
@@ -138,27 +138,27 @@
                 
                 <!-- Benefits Grid -->
                 <div class="benefits-grid">
-                    <div class="benefit-card scroll-reveal" data-bg="europa">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('images/europa-karte.png');">
                         <img src="images/europa-karte.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit1.title">
                         <h3 data-translate="fuelcard.benefit1.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit1.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" data-bg="diesel">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('images/diesel-preise.png');">
                         <img src="images/diesel-preise.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit2.title">
                         <h3 data-translate="fuelcard.benefit2.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit2.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" data-bg="sicherheit">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('images/sicherheit.png');">
                         <img src="images/sicherheit.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit3.title">
                         <h3 data-translate="fuelcard.benefit3.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit3.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" data-bg="abrechnung">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('images/abrechnung.png');">
                         <img src="images/abrechnung.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit4.title">
                         <h3 data-translate="fuelcard.benefit4.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit4.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" data-bg="service">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('images/service.png');">
                         <img src="images/service.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit5.title">
                         <h3 data-translate="fuelcard.benefit5.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit5.description">Loading...</p>


### PR DESCRIPTION
## Summary
- render benefit cards with inline `background-image` styles
- tweak benefit card gradient overlay styles
- remove obsolete `[data-bg]` rules

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68776941db388323936c9365d5373e3f