### PR TITLE
Fix image 403 errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
         <!-- Hero Section -->
         <section id="start" class="hero">
             <div class="fuel-card">
-                <div class="rmc-logo" style="background-image: url('images/rmclogo.png');"></div>
+                <div class="rmc-logo" style="background-image: url('./images/rmclogo.png');"></div>
                 <div class="wave"></div>
                 <div class="wave"></div>
                 <div class="wave"></div>
@@ -138,28 +138,28 @@
                 
                 <!-- Benefits Grid -->
                 <div class="benefits-grid">
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/europa-karte.png');">
-                        <img src="images/europa-karte.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit1.title">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/europa-karte.png');">
+                        <img src="./images/europa-karte.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit1.title">
                         <h3 data-translate="fuelcard.benefit1.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit1.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/diesel-preise.png');">
-                        <img src="images/diesel-preise.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit2.title">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/diesel-preise.png');">
+                        <img src="./images/diesel-preise.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit2.title">
                         <h3 data-translate="fuelcard.benefit2.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit2.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/sicherheit.png');">
-                        <img src="images/sicherheit.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit3.title">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/sicherheit.png');">
+                        <img src="./images/sicherheit.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit3.title">
                         <h3 data-translate="fuelcard.benefit3.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit3.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/abrechnung.png');">
-                        <img src="images/abrechnung.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit4.title">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/abrechnung.png');">
+                        <img src="./images/abrechnung.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit4.title">
                         <h3 data-translate="fuelcard.benefit4.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit4.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('images/service.png');">
-                        <img src="images/service.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit5.title">
+                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/service.png');">
+                        <img src="./images/service.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit5.title">
                         <h3 data-translate="fuelcard.benefit5.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit5.description">Loading...</p>
                     </div>


### PR DESCRIPTION
## Summary
- use explicit `./images/` relative paths so the benefit card images are served from the same directory

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68776aa37e388323834c8812a80401f3