### PR TITLE
Use img tags for benefits and RMC logo

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -381,9 +381,6 @@
 
         .benefit-card {
             background: var(--white);
-            background-size: cover;
-            background-position: center;
-            background-repeat: no-repeat;
             padding: 2.5rem;
             border-radius: var(--border-radius);
             box-shadow: var(--shadow);
@@ -395,6 +392,17 @@
             display: flex;
             flex-direction: column;
             justify-content: center;
+        }
+
+        .benefit-bg-image {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            object-position: center;
+            z-index: 0;
         }
 
         .benefit-card::before {

--- a/index.html
+++ b/index.html
@@ -57,7 +57,9 @@
         <!-- Hero Section -->
         <section id="start" class="hero">
             <div class="fuel-card">
-                <div class="rmc-logo" style="background-image: url('./images/rmclogo.png');"></div>
+                <div class="rmc-logo">
+                    <img src="./images/rmclogo.png" style="width: 100%; height: 100%; object-fit: contain;" alt="RMC">
+                </div>
                 <div class="wave"></div>
                 <div class="wave"></div>
                 <div class="wave"></div>
@@ -138,27 +140,32 @@
                 
                 <!-- Benefits Grid -->
                 <div class="benefits-grid">
-                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/europa-karte.png');">
+                    <div class="benefit-card scroll-reveal">
+                        <img src="./images/europa-karte.png" class="benefit-bg-image" loading="lazy" alt="">
                         <img src="./images/europa-karte.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit1.title">
                         <h3 data-translate="fuelcard.benefit1.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit1.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/diesel-preise.png');">
+                    <div class="benefit-card scroll-reveal">
+                        <img src="./images/diesel-preise.png" class="benefit-bg-image" loading="lazy" alt="">
                         <img src="./images/diesel-preise.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit2.title">
                         <h3 data-translate="fuelcard.benefit2.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit2.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/sicherheit.png');">
+                    <div class="benefit-card scroll-reveal">
+                        <img src="./images/sicherheit.png" class="benefit-bg-image" loading="lazy" alt="">
                         <img src="./images/sicherheit.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit3.title">
                         <h3 data-translate="fuelcard.benefit3.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit3.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/abrechnung.png');">
+                    <div class="benefit-card scroll-reveal">
+                        <img src="./images/abrechnung.png" class="benefit-bg-image" loading="lazy" alt="">
                         <img src="./images/abrechnung.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit4.title">
                         <h3 data-translate="fuelcard.benefit4.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit4.description">Loading...</p>
                     </div>
-                    <div class="benefit-card scroll-reveal" style="background-image: url('./images/service.png');">
+                    <div class="benefit-card scroll-reveal">
+                        <img src="./images/service.png" class="benefit-bg-image" loading="lazy" alt="">
                         <img src="./images/service.png" class="benefit-icon" loading="lazy" alt="" data-translate="fuelcard.benefit5.title">
                         <h3 data-translate="fuelcard.benefit5.title">Loading...</h3>
                         <p data-translate="fuelcard.benefit5.description">Loading...</p>


### PR DESCRIPTION
## Summary
- avoid using CSS background-image to fix 403 image loads
- add `.benefit-bg-image` helper and include img tags for benefits
- replace RMC logo background with an img element

## Testing
- `tidy -errors -q index.html`

------
https://chatgpt.com/codex/tasks/task_e_687772d351188323a0454b3bfe5da853