### PR TITLE
Implement template-based cache busting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ webhook.php
 
 # Ignoriere die Log-Datei
 webhook.log
+index.html

--- a/index.template.html
+++ b/index.template.html
@@ -8,27 +8,10 @@
     <title data-translate="page.title">Loading...</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚛</text></svg>">
     
-    <!-- CSS und JavaScript mit Cache-Busting laden -->
-    <script>
-        const timestamp = Date.now();
-
-        // CSS
-        const cssLink = document.createElement('link');
-        cssLink.rel = 'stylesheet';
-        cssLink.href = 'css/styles.css?v=' + timestamp;
-        document.head.appendChild(cssLink);
-
-        // JavaScript files
-        const translationsScript = document.createElement('script');
-        translationsScript.src = 'js/translations.js?v=' + timestamp;
-        translationsScript.defer = true;
-        document.head.appendChild(translationsScript);
-
-        const mainScript = document.createElement('script');
-        mainScript.src = 'js/main.js?v=' + timestamp;
-        mainScript.defer = true;
-        document.head.appendChild(mainScript);
-    </script>
+    <!-- CSS und JavaScript ohne Cache-Busting -->
+    <link rel="stylesheet" href="css/styles.css">
+    <script src="js/translations.js" defer></script>
+    <script src="js/main.js" defer></script>
 
     <!-- Hreflang dynamisch setzen -->
     <link rel="alternate" hreflang="de" href="https://www.filo.cards/">


### PR DESCRIPTION
## Summary
- rename `index.html` to `index.template.html`
- load CSS and JS in the template without timestamps
- ignore generated `index.html`
- document how the deployment webhook generates the file with timestamps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68779bc6275083238d8974a9fe14ae31