### PR TITLE
Add world map section with JS grid

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1209,6 +1209,10 @@
                 min-height: 280px;
             }
         }
+.worldmap-section {
+    margin: 4rem 0;
+    text-align: center;
+}
 
         .worldmap-container {
             margin: 4rem auto;
@@ -1223,7 +1227,7 @@
             font-weight: 600;
         }
 
-        .worldmap-grid {
+        .worldmap-container {
             display: grid;
             grid-template-columns: repeat(55, 1fr);
             grid-template-rows: repeat(35, 1fr);
@@ -1298,7 +1302,7 @@
         }
 
         @media (max-width: 768px) {
-            .worldmap-grid {
+            .worldmap-container {
                 padding: 1rem;
             }
 

--- a/index.template.html
+++ b/index.template.html
@@ -137,12 +137,10 @@
         </div>
 
         <!-- NEUE WELTKARTE -->
-        <div class="worldmap-container">
+        <div class="worldmap-section">
             <h3 class="worldmap-title">Europaweit vernetzt</h3>
-            <div class="worldmap-grid">
-                <div class="worldmap-cell"></div>
-                <div class="worldmap-cell"></div>
-                <!-- Insgesamt 1925 Zellen (35 * 55) -->
+            <div class="worldmap-container">
+                <!-- 1925 Zellen werden per JavaScript generiert -->
             </div>
         </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -309,13 +309,12 @@ window.debugTranslations = function() {
 
 // Generate worldmap cells after DOM load
 document.addEventListener('DOMContentLoaded', function() {
-    const worldmapGrid = document.querySelector('.worldmap-grid');
-    if (worldmapGrid) {
-        for (let i = 0; i < 1925; i++) {
+    const container = document.querySelector('.worldmap-container');
+    if (container) {
+        for (let i = 0; i < 35 * 55; i++) {
             const cell = document.createElement('div');
             cell.className = 'worldmap-cell';
-            cell.style.setProperty('--i', i);
-            worldmapGrid.appendChild(cell);
+            container.appendChild(cell);
         }
     }
 });


### PR DESCRIPTION
## Summary
- add `worldmap-section` markup for the services section
- generate world map cells with JS
- style worldmap container and section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877bd9f2798832399d1f19b1b5d43ea