### PR TITLE
Fix CTA prefill encoding

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -1,5 +1,10 @@
 <?php
-header('Content-Type: application/json');
+// Ensure UTF-8 encoding
+ini_set('default_charset', 'UTF-8');
+mb_internal_encoding('UTF-8');
+mb_http_output('UTF-8');
+
+header('Content-Type: application/json; charset=UTF-8');
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: POST');
 header('Access-Control-Allow-Headers: Content-Type');

--- a/data/translations.json
+++ b/data/translations.json
@@ -297,7 +297,13 @@
         "consultation": "Kostenlose Beratung anfragen",
         "fuel_card": "Jetzt Tankkarte anfragen",
         "credit_card": "Jetzt Kreditkarte beantragen",
-        "toll_solution": "Maut-Lösung anfragen"
+        "toll_solution": "Maut-Lösung anfragen",
+        "prefill": {
+          "fuel_card": "Ich interessiere mich für eine Tankkarte für mein Unternehmen.",
+          "credit_card": "Ich möchte eine Prepaid-Kreditkarte beantragen.",
+          "toll_solution": "Ich benötige eine Maut-Lösung für meine Fahrzeuge.",
+          "consultation": "Ich interessiere mich für Ihre Mobilitätslösungen."
+        }
       },
       "footer": {
         "company": "filo.cards",
@@ -610,7 +616,13 @@
         "consultation": "Request Free Consultation",
         "fuel_card": "Request Fuel Card Now",
         "credit_card": "Apply for Credit Card Now",
-        "toll_solution": "Request Toll Solution"
+        "toll_solution": "Request Toll Solution",
+        "prefill": {
+          "fuel_card": "I am interested in a fuel card for my company.",
+          "credit_card": "I would like to apply for a prepaid credit card.",
+          "toll_solution": "I need a toll solution for my vehicles.",
+          "consultation": "I am interested in your mobility solutions."
+        }
       },
       "footer": {
         "company": "filo.cards",
@@ -923,7 +935,13 @@
         "consultation": "Ücretsiz Danışmanlık Talep Edin",
         "fuel_card": "Şimdi Yakıt Kartı Talep Edin",
         "credit_card": "Şimdi Kredi Kartı Başvurusu Yapın",
-        "toll_solution": "Geçiş Ücreti Çözümü Talep Edin"
+        "toll_solution": "Geçiş Ücreti Çözümü Talep Edin",
+        "prefill": {
+          "fuel_card": "Şirketim için yakıt kartı ile ilgileniyorum.",
+          "credit_card": "Ön ödemeli kredi kartı başvurusu yapmak istiyorum.",
+          "toll_solution": "Araçlarım için geçiş ücreti çözümüne ihtiyacım var.",
+          "consultation": "Mobilite çözümlerinizle ilgileniyorum."
+        }
       },
       "footer": {
         "company": "filo.cards",

--- a/js/main.js
+++ b/js/main.js
@@ -293,43 +293,37 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
+
 // CTA Button tracking and form pre-fill
 document.addEventListener('DOMContentLoaded', function() {
     document.querySelectorAll('.cta-btn').forEach(btn => {
         btn.addEventListener('click', function(e) {
             // Get CTA context from translation key
             const translationKey = this.getAttribute('data-translate');
-            const ctaType = translationKey ? translationKey.split('.')[1] : 'general';
+            const ctaType = translationKey ? translationKey.split('.')[1] : 'consultation';
 
-            // Pre-fill form message based on CTA
+            // Pre-fill form message based on CTA using translation system
             setTimeout(() => {
                 const messageField = document.getElementById('message');
-                if (messageField && !messageField.value) {
-                    let preMessage = '';
-                    switch(ctaType) {
-                        case 'fuel_card':
-                            preMessage = 'Ich interessiere mich f\xC3\xBCr eine Tankkarte f\xC3\xBCr mein Unternehmen.';
-                            break;
-                        case 'credit_card':
-                            preMessage = 'Ich m\xC3\xB6chte eine Prepaid-Kreditkarte beantragen.';
-                            break;
-                        case 'toll_solution':
-                            preMessage = 'Ich ben\xC3\xB6tige eine Maut-L\xC3\xB6sung f\xC3\xBCr meine Fahrzeuge.';
-                            break;
-                        case 'consultation':
-                            preMessage = 'Ich interessiere mich f\xC3\xBCr Ihre Mobilit\xC3\xA4tsl\xC3\xB6sungen.';
-                            break;
-                    }
+                if (messageField && !messageField.value && window.translationLoader) {
+                    const prefillKey = `cta.prefill.${ctaType}`;
+                    const preMessage = window.translationLoader.getTranslation(prefillKey, currentLanguage);
 
-                    if (preMessage && currentLanguage === 'de') {
+                    // Only set if translation exists and is not the key itself
+                    if (preMessage && preMessage !== prefillKey) {
                         messageField.value = preMessage;
+
+                        // Add visual feedback
+                        messageField.style.backgroundColor = '#f0f8ff';
+                        setTimeout(() => {
+                            messageField.style.backgroundColor = '';
+                        }, 1000);
                     }
                 }
             }, 500);
         });
     });
 });
-
 // Scroll Effects
 window.addEventListener('scroll', function() {
     const nav = document.querySelector('.nav');
@@ -387,6 +381,17 @@ window.debugTranslations = function() {
     });
 };
 
+// Debug function to test pre-fill messages
+window.testPrefill = function() {
+    console.log('Testing CTA prefill messages:');
+    const types = ['fuel_card', 'credit_card', 'toll_solution', 'consultation'];
+
+    types.forEach(type => {
+        const key = `cta.prefill.${type}`;
+        const message = window.translationLoader.getTranslation(key, currentLanguage);
+        console.log(`${type}:`, message);
+    });
+};
 // Generate worldmap cells with random animation delays
 document.addEventListener('DOMContentLoaded', function() {
     const container = document.querySelector('.worldmap-container');


### PR DESCRIPTION
## Summary
- add CTA prefill messages to all languages
- update CTA button JS logic to use translation loader
- highlight autofilled message and add debug helper
- ensure UTF-8 encoding defaults in `contact.php`

## Testing
- `php -l contact.php`
- `node --check js/main.js`
- `node --check js/translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68781f649af88323b0c9d5753bc98097