### PR TITLE
Fix Font Awesome failover

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -13,7 +13,7 @@
     
     <!-- CSS und JavaScript mit Cache-Busting -->
     <link rel="stylesheet" href="css/styles.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" onerror="this.onerror=null;this.href='https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css'">
     <script src="js/translations.js" defer></script>
     <script src="js/main.js" defer></script>
 


### PR DESCRIPTION
## Summary
- load Font Awesome via cdnjs with a JSDelivr fallback

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6878c67296308323bb200564f8652cc1