### PR TITLE
Fix icons removed by translation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1305,31 +1305,45 @@
             box-shadow: 0 4px 12px rgba(0,0,0,0.15);
         }
 
-        .finder-btn i {
-            font-size: 1rem;
-            width: 16px;
-            text-align: center;
+        /* Icons via pseudo-elements */
+        .station-finder-text h3::before {
+            content: '\f3c5'; /* fa-map-marker-alt */
+            font-family: "Font Awesome 6 Free";
+            font-weight: 900;
+            margin-right: 0.5rem;
+            color: var(--primary-yellow);
         }
 
-        /* Icon colors */
-        .finder-btn .fa-globe {
+        .finder-btn-web::before {
+            content: '\f0ac'; /* fa-globe */
+            font-family: "Font Awesome 6 Free";
+            font-weight: 900;
+            margin-right: 0.5rem;
             color: var(--primary-green);
         }
 
-        .finder-btn .fa-android {
+        .finder-btn-android::before {
+            content: '\f17b'; /* fa-android */
+            font-family: "Font Awesome 6 Brands";
+            font-weight: 400;
+            margin-right: 0.5rem;
             color: #3DDC84;
         }
 
-        .finder-btn .fa-apple {
+        .finder-btn-ios::before {
+            content: '\f179'; /* fa-apple */
+            font-family: "Font Awesome 6 Brands";
+            font-weight: 400;
+            margin-right: 0.5rem;
             color: #000000;
         }
 
-        .finder-btn .fa-info-circle {
+        .finder-btn-info::before {
+            content: '\f05a'; /* fa-info-circle */
+            font-family: "Font Awesome 6 Free";
+            font-weight: 900;
+            margin-right: 0.5rem;
             color: var(--white);
-        }
-
-        .finder-btn .fa-map-marker-alt {
-            color: var(--primary-yellow);
         }
 
         /* Special styling for info button */

--- a/index.template.html
+++ b/index.template.html
@@ -236,23 +236,15 @@
                     <div class="station-finder-bar">
                         <div class="station-finder-content">
                             <div class="station-finder-text">
-                                <h3 data-translate="station_finder.title"><i class="fas fa-map-marker-alt"></i> Tankstellen-Finder</h3>
+                                <h3 data-translate="station_finder.title">Tankstellen-Finder</h3>
                                 <p data-translate="station_finder.description">Finden Sie die nächste RMC-Tankstelle</p>
                             </div>
 
                             <div class="station-finder-buttons">
-                                <a href="https://finder.rmc-service.com/rmc/map" target="_blank" class="finder-btn finder-btn-web" data-translate="station_finder.web">
-                                    <i class="fas fa-globe"></i> Web
-                                </a>
-                                <a href="https://play.google.com/store/apps/details?id=at.rmc.app" target="_blank" class="finder-btn finder-btn-android" data-translate="station_finder.android">
-                                    <i class="fab fa-android"></i> Android
-                                </a>
-                                <a href="https://apps.apple.com/at/app/rmc-finder/id6477531013" target="_blank" class="finder-btn finder-btn-ios" data-translate="station_finder.ios">
-                                    <i class="fab fa-apple"></i> iOS
-                                </a>
-                                <a href="https://www.rmc-service.com/de/tankstellenfinder/tankstellennetz" target="_blank" class="finder-btn finder-btn-info" data-translate="station_finder.more_info">
-                                    <i class="fas fa-info-circle"></i> Mehr Infos
-                                </a>
+                                <a href="https://finder.rmc-service.com/rmc/map" target="_blank" class="finder-btn finder-btn-web" data-translate="station_finder.web">Web</a>
+                                <a href="https://play.google.com/store/apps/details?id=at.rmc.app" target="_blank" class="finder-btn finder-btn-android" data-translate="station_finder.android">Android</a>
+                                <a href="https://apps.apple.com/at/app/rmc-finder/id6477531013" target="_blank" class="finder-btn finder-btn-ios" data-translate="station_finder.ios">iOS</a>
+                                <a href="https://www.rmc-service.com/de/tankstellenfinder/tankstellennetz" target="_blank" class="finder-btn finder-btn-info" data-translate="station_finder.more_info">Mehr Infos</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- keep station finder icons visible by using CSS pseudo-elements instead of `<i>` tags
- drop old HTML icons and adjust CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878cc16e69483239ddb07cce6a038fc