### PR TITLE
Add credit card header and update contact titles

### DIFF
--- a/data/translations.json
+++ b/data/translations.json
@@ -275,7 +275,7 @@
         }
       },
       "contact": {
-        "title": "LKW-Tankkarte beantragen",
+        "title": "Kontaktieren Sie uns",
         "subtitle": "Sie möchten eine Dieselkarte für Ihre LKW-Flotte beantragen?<br>Kontaktieren Sie uns – wir beraten Sie persönlich und kostenlos!",
         "form": {
           "name": "Name *",
@@ -602,7 +602,7 @@
         }
       },
       "contact": {
-        "title": "Apply for truck fuel card",
+        "title": "Contact Us",
         "subtitle": "Would you like to apply for a fuel card for your truck fleet?<br>Contact us – we advise you personally and free of charge!",
         "form": {
           "name": "Name *",
@@ -929,7 +929,7 @@
         }
       },
       "contact": {
-        "title": "Kamyon yakıt kartı başvurusu",
+        "title": "Bizimle İletişime Geçin",
         "subtitle": "Kamyon filonuz için bir yakıt kartı başvurusu yapmak mı istiyorsunuz?<br>Bizimle iletişime geçin – size kişisel ve ücretsiz danışmanlık veriyoruz!",
         "form": {
           "name": "İsim *",

--- a/index.template.html
+++ b/index.template.html
@@ -270,6 +270,7 @@
             <div class="container">
 
                 <!-- Credit Card Content -->
+                <h2 class="section-title" data-translate="creditcard.title">Loading...</h2>
                 <p class="section-subtitle" data-translate="creditcard.subtitle">Loading...</p>
                 
                 <!-- Usage Grid -->


### PR DESCRIPTION
## Summary
- show credit card heading in Payment & Mobility section
- rename contact form heading for DE/EN/TR translations

## Testing
- `php -l contact.php`
- `php -l rotate_logs.php`
- `php -l view_logs.php`


------
https://chatgpt.com/codex/tasks/task_e_6878cf1d4dbc832389fb12c881aa934e