### PR TITLE
Add debug config helpers for admin

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1,4 +1,57 @@
 <?php
+// EMERGENCY DEBUG MODE
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+ini_set('log_errors', 1);
+
+// SAFE CONFIG LOADING
+function safeLoadConfig($configFile) {
+    if (!file_exists($configFile)) {
+        die("DEBUG: Config file does not exist: $configFile");
+    }
+
+    $content = file_get_contents($configFile);
+    if ($content === false) {
+        die("DEBUG: Cannot read config file");
+    }
+
+    echo "<!-- DEBUG: Config file size: " . strlen($content) . " bytes -->\n";
+
+    $config = json_decode($content, true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        die("DEBUG: JSON Error: " . json_last_error_msg());
+    }
+
+    echo "<!-- DEBUG: Config loaded successfully -->\n";
+    return $config;
+}
+
+// SAFE getConfigValue
+function safeGetConfigValue($config, $path, $default = '') {
+    try {
+        if (!is_array($config)) {
+            echo "<!-- DEBUG: Config is not array, type: " . gettype($config) . " -->\n";
+            return $default;
+        }
+
+        $keys = explode('.', $path);
+        $value = $config;
+        foreach ($keys as $key) {
+            if (isset($value[$key])) {
+                $value = $value[$key];
+            } else {
+                echo "<!-- DEBUG: Missing key '$key' in path '$path' -->\n";
+                return $default;
+            }
+        }
+        echo "<!-- DEBUG: Successfully got value for '$path' -->\n";
+        return $value;
+    } catch (Exception $e) {
+        echo "<!-- DEBUG: Exception in getConfigValue: " . $e->getMessage() . " -->\n";
+        return $default;
+    }
+}
+
 session_start();
 
 $adminPassword = 'FiloCards2025!Admin';
@@ -39,16 +92,7 @@ if (isset($_POST['save_config']) && $_SESSION['admin_logged_in']) {
 }
 
 // Load current config safely
-$currentConfig = [];
-$rawConfig = @file_get_contents($configFile);
-if ($rawConfig !== false) {
-    $currentConfig = json_decode($rawConfig, true);
-    if (!is_array($currentConfig)) {
-        $currentConfig = [];
-    }
-} else {
-    $error = 'Konnte Konfigurationsdatei nicht laden';
-}
+$currentConfig = safeLoadConfig($configFile);
 
 // Fallback-Werte definieren (aktuelle Website-Inhalte)
 $defaultValues = [
@@ -253,59 +297,61 @@ exit;
                     <h3>Kontakt</h3>
                     <div class="form-group">
                         <label>E-Mail-Adresse</label>
-                        <input type="email" id="contact_email" value="<?php echo htmlspecialchars(getConfigValue($currentConfig, 'features.content_management.contact_email', 'o.gokceviran@rmc-service.com')); ?>">
+                        <?php echo "<!-- DEBUG: About to render contact_email input -->\n"; ?>
+                        <input type="email" id="contact_email" value="<?php echo htmlspecialchars(safeGetConfigValue($currentConfig, 'features.content_management.contact_email', 'o.gokceviran@rmc-service.com')); ?>">
+                        <?php echo "<!-- DEBUG: contact_email input rendered successfully -->\n"; ?>
                     </div>
 
                     <h3>Haupttitel</h3>
                     <div class="form-group">
                         <label>Hero Titel</label>
-                        <input type="text" id="hero_title" value="<?php echo htmlspecialchars(getConfigValue($currentConfig, 'features.content_management.titles.hero_main', 'Europäische Mobilitätslösungen | Tankkarte, Maut & Kreditkarte')); ?>">
+                        <input type="text" id="hero_title" value="<?php echo htmlspecialchars(safeGetConfigValue($currentConfig, 'features.content_management.titles.hero_main', 'Europäische Mobilitätslösungen | Tankkarte, Maut & Kreditkarte')); ?>">
                     </div>
                     <div class="form-group">
                         <label>Services Titel</label>
-                        <input type="text" id="services_title" value="<?php echo htmlspecialchars(getConfigValue($currentConfig, 'features.content_management.titles.services_main', 'Unsere Mobilitätslösungen')); ?>">
+                        <input type="text" id="services_title" value="<?php echo htmlspecialchars(safeGetConfigValue($currentConfig, 'features.content_management.titles.services_main', 'Unsere Mobilitätslösungen')); ?>">
                     </div>
                     <div class="form-group">
                         <label>Tankkarte Titel</label>
-                        <input type="text" id="fuelcard_title" value="<?php echo htmlspecialchars(getConfigValue($currentConfig, 'features.content_management.titles.fuelcard_main', 'RMC Tankkarte')); ?>">
+                        <input type="text" id="fuelcard_title" value="<?php echo htmlspecialchars(safeGetConfigValue($currentConfig, 'features.content_management.titles.fuelcard_main', 'RMC Tankkarte')); ?>">
                     </div>
                     <div class="form-group">
                         <label>Kreditkarte Titel</label>
-                        <input type="text" id="creditcard_title" value="<?php echo htmlspecialchars(getConfigValue($currentConfig, 'features.content_management.titles.creditcard_main', 'RMC Prepaid Kreditkarte')); ?>">
+                        <input type="text" id="creditcard_title" value="<?php echo htmlspecialchars(safeGetConfigValue($currentConfig, 'features.content_management.titles.creditcard_main', 'RMC Prepaid Kreditkarte')); ?>">
                     </div>
                     <div class="form-group">
                         <label>Maut Titel</label>
-                        <input type="text" id="toll_title" value="<?php echo htmlspecialchars(getConfigValue($currentConfig, 'features.content_management.titles.toll_main', 'Mautlösungen für Europa')); ?>">
+                        <input type="text" id="toll_title" value="<?php echo htmlspecialchars(safeGetConfigValue($currentConfig, 'features.content_management.titles.toll_main', 'Mautlösungen für Europa')); ?>">
                     </div>
                     <div class="form-group">
                         <label>Kontakt Titel</label>
-                        <input type="text" id="contact_title" value="<?php echo htmlspecialchars(getConfigValue($currentConfig, 'features.content_management.titles.contact_main', 'Kontaktieren Sie uns')); ?>">
+                        <input type="text" id="contact_title" value="<?php echo htmlspecialchars(safeGetConfigValue($currentConfig, 'features.content_management.titles.contact_main', 'Kontaktieren Sie uns')); ?>">
                     </div>
 
                     <h3>Externe Links</h3>
                     <div class="form-group">
                         <label>Station Finder Web</label>
-                        <input type="url" id="finder_web" value="<?php echo getConfigValue($currentConfig, 'features.content_management.external_urls.station_finder_web', 'https://finder.rmc-service.com/rmc/map'); ?>">
+                        <input type="url" id="finder_web" value="<?php echo safeGetConfigValue($currentConfig, 'features.content_management.external_urls.station_finder_web', 'https://finder.rmc-service.com/rmc/map'); ?>">
                     </div>
                     <div class="form-group">
                         <label>Android App</label>
-                        <input type="url" id="finder_android" value="<?php echo getConfigValue($currentConfig, 'features.content_management.external_urls.station_finder_android', 'https://play.google.com/store/apps/details?id=at.rmc.app'); ?>">
+                        <input type="url" id="finder_android" value="<?php echo safeGetConfigValue($currentConfig, 'features.content_management.external_urls.station_finder_android', 'https://play.google.com/store/apps/details?id=at.rmc.app'); ?>">
                     </div>
                     <div class="form-group">
                         <label>iOS App</label>
-                        <input type="url" id="finder_ios" value="<?php echo getConfigValue($currentConfig, 'features.content_management.external_urls.station_finder_ios', 'https://apps.apple.com/at/app/rmc-finder/id6477531013'); ?>">
+                        <input type="url" id="finder_ios" value="<?php echo safeGetConfigValue($currentConfig, 'features.content_management.external_urls.station_finder_ios', 'https://apps.apple.com/at/app/rmc-finder/id6477531013'); ?>">
                     </div>
                     <div class="form-group">
                         <label>RMC Info DE</label>
-                        <input type="url" id="rmc_info_de" value="<?php echo getConfigValue($currentConfig, 'features.content_management.external_urls.rmc_info_de', 'https://www.rmc-service.com/de/tankstellenfinder/tankstellennetz'); ?>">
+                        <input type="url" id="rmc_info_de" value="<?php echo safeGetConfigValue($currentConfig, 'features.content_management.external_urls.rmc_info_de', 'https://www.rmc-service.com/de/tankstellenfinder/tankstellennetz'); ?>">
                     </div>
                     <div class="form-group">
                         <label>RMC Info EN</label>
-                        <input type="url" id="rmc_info_en" value="<?php echo getConfigValue($currentConfig, 'features.content_management.external_urls.rmc_info_en', 'https://www.rmc-service.com/en/station-finder/station-network'); ?>">
+                        <input type="url" id="rmc_info_en" value="<?php echo safeGetConfigValue($currentConfig, 'features.content_management.external_urls.rmc_info_en', 'https://www.rmc-service.com/en/station-finder/station-network'); ?>">
                     </div>
                     <div class="form-group">
                         <label>RMC Info TR</label>
-                        <input type="url" id="rmc_info_tr" value="<?php echo getConfigValue($currentConfig, 'features.content_management.external_urls.rmc_info_tr', 'https://www.rmc-service.com/tr/istasyon-bulucu/istasyon-agi'); ?>">
+                        <input type="url" id="rmc_info_tr" value="<?php echo safeGetConfigValue($currentConfig, 'features.content_management.external_urls.rmc_info_tr', 'https://www.rmc-service.com/tr/istasyon-bulucu/istasyon-agi'); ?>">
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add emergency debug mode and safe config loaders
- call the new helpers when rendering the admin panel
- inject debug output around the contact email field

## Testing
- `php -l admin/index.php`

------
https://chatgpt.com/codex/tasks/task_e_687960b95f548323a40414c049ff3b7a