### PR TITLE
Add static OG tags

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -12,6 +12,22 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <link rel="canonical" href="https://www.filo.cards/">
+    <!-- Open Graph Tags (Static for Social Media) -->
+    <meta property="og:title" content="Europäische Mobilitätslösungen | Tankkarte, Maut & Kreditkarte">
+    <meta property="og:description" content="Tankkarte, Maut & Kreditkarte für Europa. Bargeldlos tanken, transparent abrechnen. Partner von RMC Service GmbH.">
+    <meta property="og:image" content="https://www.filo.cards/images/filo-cards-og.jpg">
+    <meta property="og:url" content="https://www.filo.cards/">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="filo.cards">
+    <meta property="og:locale" content="de_DE">
+
+    <!-- Twitter Cards -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Europäische Mobilitätslösungen | Tankkarte, Maut & Kreditkarte">
+    <meta name="twitter:description" content="Tankkarte, Maut & Kreditkarte für Europa. Bargeldlos tanken, transparent abrechnen. Partner von RMC Service GmbH.">
+    <meta name="twitter:image" content="https://www.filo.cards/images/filo-cards-og.jpg">
+    <meta name="twitter:site" content="@filocards">
+
     <!-- Preconnect für Performance -->
     <link rel="preconnect" href="https://www.googletagmanager.com">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com">


### PR DESCRIPTION
## Summary
- add static Open Graph and Twitter card tags to the head of the template for better social media previews

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879725887c083238a1f591d3bb132b4