### PR TITLE
Remove obsolete multilingual artifacts

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -51,8 +51,6 @@
     RewriteRule ^maut/?$ /#payment-mobility [R=301,L]
     RewriteRule ^kontakt/?$ /#support [R=301,L]
 
-    # Turkish URLs
-    RewriteRule ^tr/yakit-karti/?$ /tr/#fuel-solutions [R=301,L]
-    RewriteRule ^tr/kredi-karti/?$ /tr/#payment-mobility [R=301,L]
-    RewriteRule ^tr/gecis-ucreti/?$ /tr/#payment-mobility [R=301,L]
+    # Remove old Turkish URLs (redirect to main page)
+    RewriteRule ^tr/?$ / [R=301,L]
 </IfModule>

--- a/index.template.html
+++ b/index.template.html
@@ -49,7 +49,6 @@
 
     <!-- Hreflang dynamisch setzen -->
     <link rel="alternate" hreflang="de" href="https://www.filo.cards/">
-    <link rel="alternate" hreflang="tr" href="https://www.filo.cards/">
     <link rel="alternate" hreflang="x-default" href="https://www.filo.cards/">
     
 </head>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,42 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   
-  <!-- Main Pages -->
+  <!-- Main Page (supports all languages via JavaScript) -->
   <url>
     <loc>https://www.filo.cards/</loc>
     <lastmod>2025-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="de" href="https://www.filo.cards/" />
-    <xhtml:link rel="alternate" hreflang="tr" href="https://www.filo.cards/tr/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://www.filo.cards/en/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.filo.cards/" />
-  </url>
-  
-  <url>
-    <loc>https://www.filo.cards/tr/</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="de" href="https://www.filo.cards/" />
-    <xhtml:link rel="alternate" hreflang="tr" href="https://www.filo.cards/tr/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://www.filo.cards/en/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.filo.cards/" />
   </url>
 
-  <url>
-    <loc>https://www.filo.cards/en/</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="de" href="https://www.filo.cards/" />
-    <xhtml:link rel="alternate" hreflang="tr" href="https://www.filo.cards/tr/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://www.filo.cards/en/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.filo.cards/" />
-  </url>
-
-  <!-- Service Pages (Virtual URLs for better SEO) -->
+  <!-- Service Pages (Virtual URLs for SEO) -->
   <url>
     <loc>https://www.filo.cards/tankkarte</loc>
     <lastmod>2025-07-17</lastmod>
@@ -63,28 +36,6 @@
     <lastmod>2025-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
-  </url>
-
-  <!-- Turkish Service Pages -->
-  <url>
-    <loc>https://www.filo.cards/tr/yakit-karti</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://www.filo.cards/tr/kredi-karti</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://www.filo.cards/tr/gecis-ucreti</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
 
 </urlset>


### PR DESCRIPTION
## Summary
- update sitemap.xml to reflect JS-based translations
- simplify SEO redirects and drop Turkish URL rules
- clean up hreflang tags

## Testing
- `php -l rotate_logs.php`
- `php -l view_logs.php`
- `php -l test.php`
- `php -l admin/index.php`
- `php -l contact.php`


------
https://chatgpt.com/codex/tasks/task_e_687975922d908323a64407ab1187667e