### PR TITLE
Implement SEO landing pages system

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -53,4 +53,19 @@
 
     # Remove old Turkish URLs (redirect to main page)
     RewriteRule ^tr/?$ / [R=301,L]
+
+    # SEO Landing Pages Redirects
+    RewriteRule ^tankkarte-europa/?$ seo/tankkarte-europa-de.html [L]
+    RewriteRule ^fuel-card-europe/?$ seo/tankkarte-europa-en.html [L]
+    RewriteRule ^yakit-karti-avrupa/?$ seo/tankkarte-europa-tr.html [L]
+
+    RewriteRule ^maut-europa/?$ seo/maut-europa-lkw-de.html [L]
+    RewriteRule ^toll-europe/?$ seo/maut-europa-lkw-en.html [L]
+    RewriteRule ^gecis-ucreti-avrupa/?$ seo/maut-europa-lkw-tr.html [L]
+
+    RewriteRule ^fleet-credit-card/?$ seo/prepaid-kreditkarte-flotte-en.html [L]
+    RewriteRule ^filo-kredi-karti/?$ seo/prepaid-kreditkarte-flotte-tr.html [L]
+
+    # Sitemap Integration
+    RewriteRule ^sitemap-seo\.xml$ seo/sitemap-seo.xml [L]
 </IfModule>

--- a/admin/index.php
+++ b/admin/index.php
@@ -383,6 +383,28 @@ exit;
                 </div>
             </div>
 
+            <!-- SEO Landing Pages Section -->
+            <div class="card">
+                <h2>SEO Landing Pages</h2>
+                <div class="feature-toggle">
+                    <div>
+                        <strong>SEO Landing Pages</strong>
+                        <br><small>Statische SEO-optimierte Seiten mit Redirects</small>
+                    </div>
+                    <label class="toggle">
+                        <input type="checkbox" id="seo_landing_enabled" <?php echo $currentConfig['features']['seo_landing_pages']['enabled'] ? 'checked' : ''; ?>>
+                        <span class="slider"></span>
+                    </label>
+                </div>
+                
+                <div class="form-group">
+                    <label>Redirect Delay (Sekunden)</label>
+                    <input type="number" id="redirect_delay" value="<?php echo $currentConfig['features']['seo_landing_pages']['redirect_delay'] ?? 3; ?>" min="0" max="10">
+                </div>
+                
+                <button type="button" class="btn" onclick="regenerateSEOPages()">SEO Pages neu generieren</button>
+            </div>
+
             <!-- Future Features -->
             <div class="card">
                 <h2>Zukünftige Features</h2>
@@ -464,12 +486,29 @@ exit;
                             critical_css: true,
                             preload_fonts: true
                         }
+                    },
+                    seo_landing_pages: {
+                        enabled: document.getElementById('seo_landing_enabled').checked,
+                        auto_generate: true,
+                        redirect_delay: parseInt(document.getElementById('redirect_delay').value, 10) || 3,
+                        track_visits: true
                     }
                 }
             };
-            
+
             document.getElementById('configData').value = JSON.stringify(config);
         });
+
+        function regenerateSEOPages() {
+            fetch('generate-seo-pages.php')
+                .then(response => response.text())
+                .then(data => {
+                    alert('SEO Pages wurden neu generiert!');
+                })
+                .catch(error => {
+                    alert('Fehler: ' + error);
+                });
+        }
     </script>
 </body>
 </html>

--- a/data/feature-flags.json
+++ b/data/feature-flags.json
@@ -56,6 +56,12 @@
                 "critical_css": true,
                 "preload_fonts": true
             }
+        },
+        "seo_landing_pages": {
+            "enabled": true,
+            "auto_generate": true,
+            "redirect_delay": 3,
+            "track_visits": true
         }
     }
 }

--- a/generate-seo-pages.php
+++ b/generate-seo-pages.php
@@ -1,0 +1,355 @@
+<?php
+// SEO Pages Generator für filo.cards
+require_once 'translations-loader.php';
+
+class SEOPageGenerator {
+    private $translations;
+    private $languages = ['de', 'tr', 'en'];
+    private $outputDir = 'seo/';
+    
+    public function __construct() {
+        $this->translations = json_decode(file_get_contents('data/translations.json'), true)['translations'];
+        if (!is_dir($this->outputDir)) {
+            mkdir($this->outputDir, 0755, true);
+        }
+    }
+    
+    public function generateAllPages() {
+        $keywords = $this->getKeywordMapping();
+        
+        foreach ($keywords as $keyword => $config) {
+            foreach ($this->languages as $lang) {
+                $this->generatePage($keyword, $lang, $config);
+            }
+        }
+        
+        $this->generateSitemap();
+    }
+    
+    private function getKeywordMapping() {
+        return [
+            'tankkarte-europa' => [
+                'de' => ['title' => 'Tankkarte Europa - Günstiger Diesel für LKW Flotten', 'focus' => 'fuelcard'],
+                'tr' => ['title' => 'Avrupa Yakıt Kartı - Ucuz Dizel TIR Filolar', 'focus' => 'fuelcard'],
+                'en' => ['title' => 'Europe Fuel Card - Cheap Diesel for Truck Fleets', 'focus' => 'fuelcard']
+            ],
+            'maut-europa-lkw' => [
+                'de' => ['title' => 'LKW Maut Europa - EETS Mautbox für alle Länder', 'focus' => 'toll'],
+                'tr' => ['title' => 'Avrupa TIR Geçiş Üreti - Tek Cihazla Tüm Ülkeler', 'focus' => 'toll'],
+                'en' => ['title' => 'European Truck Toll - EETS Box for All Countries', 'focus' => 'toll']
+            ],
+            'prepaid-kreditkarte-flotte' => [
+                'de' => ['title' => 'Prepaid Kreditkarte Flotte - Ohne Schufa für LKW Fahrer', 'focus' => 'creditcard'],
+                'tr' => ['title' => 'Filo Ön Ödemeli Kartı - Kredi Kontrolsüz TIR Şoförleri', 'focus' => 'creditcard'],
+                'en' => ['title' => 'Fleet Prepaid Credit Card - No Credit Check for Drivers', 'focus' => 'creditcard']
+            ],
+            'flottenmanagement-telematik' => [
+                'de' => ['title' => 'Flottenmanagement Telematik - GPS Fahrzeugortung Europa', 'focus' => 'telematics'],
+                'tr' => ['title' => 'Filo Yönetimi Telematik - GPS Araç Takip Avrupa', 'focus' => 'telematics'],
+                'en' => ['title' => 'Fleet Management Telematics - GPS Vehicle Tracking Europe', 'focus' => 'telematics']
+            ]
+        ];
+    }
+    
+    private function generatePage($keyword, $lang, $config) {
+        $filename = "{$this->outputDir}{$keyword}-{$lang}.html";
+        $pageConfig = $config[$lang];
+        $content = $this->buildPageContent($keyword, $lang, $pageConfig);
+        
+        file_put_contents($filename, $content);
+        echo "Generated: $filename\n";
+    }
+    
+    private function buildPageContent($keyword, $lang, $config) {
+        $t = $this->translations[$lang];
+        $focus = $config['focus'];
+        
+        $metaDescription = $this->generateMetaDescription($focus, $lang);
+        $structuredData = $this->generateStructuredData($config['title'], $metaDescription);
+        $contentHtml = $this->generateMainContent($focus, $lang);
+        
+        return <<<HTML
+<!DOCTYPE html>
+<html lang="{$lang}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{$config['title']}</title>
+    <meta name="description" content="{$metaDescription}">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://www.filo.cards/seo/{$keyword}-{$lang}.html">
+    
+    <!-- Redirect nach 3 Sekunden -->
+    <meta http-equiv="refresh" content="3;url=https://www.filo.cards/#{$focus}">
+    
+    <!-- Basic Styling -->
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; line-height: 1.6; }
+        .redirect-notice { background: #1B5E20; color: white; padding: 15px; border-radius: 8px; margin-bottom: 30px; }
+        .content { margin-bottom: 40px; }
+        h1 { color: #1B5E20; }
+        .features { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; margin: 30px 0; }
+        .feature { border: 1px solid #ddd; padding: 15px; border-radius: 8px; }
+    </style>
+    
+    {$structuredData}
+</head>
+<body>
+    <div class="redirect-notice">
+        ⏱️ {$this->getRedirectText($lang)} <a href="https://www.filo.cards/#{$focus}" style="color: #FFD600;">{$this->getRedirectLinkText($lang)}</a>
+    </div>
+    
+    <main class="content">
+        <h1>{$config['title']}</h1>
+        {$contentHtml}
+    </main>
+    
+    <!-- Sofortiger Redirect für JavaScript-Nutzer -->
+    <script>
+        window.location.href = 'https://www.filo.cards/#{$focus}';
+    </script>
+</body>
+</html>
+HTML;
+    }
+    
+    private function generateMainContent($focus, $lang) {
+        $t = $this->translations[$lang];
+        
+        switch($focus) {
+            case 'fuelcard':
+                return $this->generateFuelCardContent($lang, $t);
+            case 'toll':
+                return $this->generateTollContent($lang, $t);
+            case 'creditcard':
+                return $this->generateCreditCardContent($lang, $t);
+            case 'telematics':
+                return $this->generateTelematicsContent($lang, $t);
+            default:
+                return $this->generateGeneralContent($lang, $t);
+        }
+    }
+    
+    private function generateFuelCardContent($lang, $t) {
+        $countries = implode(', ', array_slice($t['fuelcard']['countries']['list'], 0, 10));
+        
+        return <<<HTML
+        <p>{$t['fuelcard']['subtitle']}</p>
+        
+        <div class="features">
+            <div class="feature">
+                <h3>{$t['fuelcard']['benefit1']['title']}</h3>
+                <p>{$t['fuelcard']['benefit1']['description']}</p>
+            </div>
+            <div class="feature">
+                <h3>{$t['fuelcard']['benefit2']['title']}</h3>
+                <p>{$t['fuelcard']['benefit2']['description']}</p>
+            </div>
+            <div class="feature">
+                <h3>{$t['fuelcard']['benefit3']['title']}</h3>
+                <p>{$t['fuelcard']['benefit3']['description']}</p>
+            </div>
+        </div>
+        
+        <h2>{$t['fuelcard']['countries']['title']}</h2>
+        <p>{$countries}</p>
+        
+        <div style="background: #FFD600; padding: 20px; border-radius: 8px; margin: 30px 0;">
+            <strong>{$t['fuelcard']['countries']['austriaSpecial']}</strong>
+        </div>
+        
+        <h2>{$t['contact']['title']}</h2>
+        <p>📞 +90 5530540989</p>
+        <p>📧 o.gokceviran@rmc-service.com</p>
+HTML;
+    }
+    
+    private function generateTollContent($lang, $t) {
+        $countries = implode(', ', array_slice($t['toll']['countries']['list'], 0, 8));
+        
+        return <<<HTML
+        <p>{$t['toll']['subtitle']}</p>
+        
+        <div class="features">
+            <div class="feature">
+                <h3>{$t['toll']['advantages']['oneProvider']['title']}</h3>
+                <p>{$t['toll']['advantages']['oneProvider']['description']}</p>
+            </div>
+            <div class="feature">
+                <h3>{$t['toll']['advantages']['eets']['title']}</h3>
+                <p>{$t['toll']['advantages']['eets']['description']}</p>
+            </div>
+            <div class="feature">
+                <h3>{$t['toll']['advantages']['billing']['title']}</h3>
+                <p>{$t['toll']['advantages']['billing']['description']}</p>
+            </div>
+        </div>
+        
+        <h2>{$t['toll']['countries']['title']}</h2>
+        <p>{$countries}</p>
+        
+        <h2>{$t['toll']['tunnel']['title']}</h2>
+        <p>{$t['toll']['tunnel']['description']}</p>
+HTML;
+    }
+    
+    private function generateCreditCardContent($lang, $t) {
+        return <<<HTML
+        <p>{$t['creditcard']['subtitle']}</p>
+        
+        <h2>{$t['creditcard']['usage']['title']}</h2>
+        <div class="features">
+            <div class="feature">
+                <h3>{$t['creditcard']['usage']['hotels']['title']}</h3>
+                <p>{$t['creditcard']['usage']['hotels']['description']}</p>
+            </div>
+            <div class="feature">
+                <h3>{$t['creditcard']['usage']['parking']['title']}</h3>
+                <p>{$t['creditcard']['usage']['parking']['description']}</p>
+            </div>
+            <div class="feature">
+                <h3>{$t['creditcard']['usage']['emergencies']['title']}</h3>
+                <p>{$t['creditcard']['usage']['emergencies']['description']}</p>
+            </div>
+        </div>
+        
+        <h2>{$t['creditcard']['benefits']['title']}</h2>
+        <div class="features">
+            <div class="feature">
+                <h3>{$t['creditcard']['benefits']['noCredit']['title']}</h3>
+                <p>{$t['creditcard']['benefits']['noCredit']['description']}</p>
+            </div>
+            <div class="feature">
+                <h3>{$t['creditcard']['benefits']['control']['title']}</h3>
+                <p>{$t['creditcard']['benefits']['control']['description']}</p>
+            </div>
+        </div>
+HTML;
+    }
+    
+    private function generateTelematicsContent($lang, $t) {
+        return <<<HTML
+        <h2>KITIN Telematik System</h2>
+        <p>Modernes Flottenmanagement mit Echtzeit-GPS-Tracking, Fahrerverhalten-Analyse und Kraftstoffoptimierung.</p>
+        
+        <div class="features">
+            <div class="feature">
+                <h3>GPS Fahrzeugortung</h3>
+                <p>Echtzeitüberwachung Ihrer Fahrzeugflotte mit präziser Standortbestimmung und Routenoptimierung.</p>
+            </div>
+            <div class="feature">
+                <h3>Treibstoffüberwachung</h3>
+                <p>Verhindern Sie Kraftstoffdiebstahl und optimieren Sie den Verbrauch durch detaillierte Analysen.</p>
+            </div>
+            <div class="feature">
+                <h3>Fahrerverhalten</h3>
+                <p>Analysieren Sie Fahrweise, Geschwindigkeit und Effizienz für bessere Kostenkontrolle.</p>
+            </div>
+        </div>
+        
+        <h2>Integration mit RMC Services</h2>
+        <p>Vollständige Integration mit Tankkarten und Mautlösungen für komplettes Flottenmanagement aus einer Hand.</p>
+HTML;
+    }
+
+    private function generateGeneralContent($lang, $t) {
+        $desc = $t['page']['description'] ?? '';
+        return "<p>{$desc}</p>";
+    }
+    
+    private function generateStructuredData($title, $description) {
+        return <<<JSON
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "{$title}",
+        "description": "{$description}",
+        "url": "https://www.filo.cards/",
+        "mainEntity": {
+            "@type": "Organization",
+            "name": "filo.cards - RMC Service GmbH",
+            "url": "https://www.filo.cards",
+            "telephone": "+90 5530540989",
+            "email": "o.gokceviran@rmc-service.com"
+        }
+    }
+    </script>
+JSON;
+    }
+    
+    private function generateSitemap() {
+        $urls = [];
+        $keywords = array_keys($this->getKeywordMapping());
+        
+        foreach ($keywords as $keyword) {
+            foreach ($this->languages as $lang) {
+                $urls[] = "https://www.filo.cards/seo/{$keyword}-{$lang}.html";
+            }
+        }
+        
+        $sitemap = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+        $sitemap .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+        
+        foreach ($urls as $url) {
+            $sitemap .= "  <url>\n";
+            $sitemap .= "    <loc>{$url}</loc>\n";
+            $sitemap .= "    <changefreq>monthly</changefreq>\n";
+            $sitemap .= "    <priority>0.8</priority>\n";
+            $sitemap .= "  </url>\n";
+        }
+        
+        $sitemap .= '</urlset>';
+        
+        file_put_contents($this->outputDir . 'sitemap-seo.xml', $sitemap);
+    }
+    
+    private function getRedirectText($lang) {
+        $texts = [
+            'de' => 'Sie werden automatisch zur Hauptseite weitergeleitet.',
+            'tr' => 'Ana sayfaya otomatik olarak yönlendiriliyorsunuz.',
+            'en' => 'You are being automatically redirected to the main page.'
+        ];
+        return $texts[$lang];
+    }
+    
+    private function getRedirectLinkText($lang) {
+        $texts = [
+            'de' => 'Direkt zur Seite',
+            'tr' => 'Doğrudan sayfaya git',
+            'en' => 'Go directly to page'
+        ];
+        return $texts[$lang];
+    }
+    
+    private function generateMetaDescription($focus, $lang) {
+        $descriptions = [
+            'de' => [
+                'fuelcard' => 'Europäische Tankkarte für Unternehmen. Günstiger Diesel, 19 Länder, keine Gebühren. Jetzt kostenlos anfragen!',
+                'toll' => 'LKW Maut Europa aus einer Hand. EETS-kompatibel für 17 Länder. Einfache Abrechnung für Speditionen.',
+                'creditcard' => 'Prepaid Firmenkreditkarte ohne Schufa. Perfekt für LKW-Fahrer. Volle Kostenkontrolle.',
+                'telematics' => 'Professionelles Flottenmanagement mit GPS-Tracking. KITIN Telematik für Europa.'
+            ],
+            'tr' => [
+                'fuelcard' => 'Kurumsal yakıt kartı Avrupa. Ucuz dizel, 19 ülke, ücretsiz. Hemen başvurun!',
+                'toll' => 'Avrupa TIR geçiş ücreti tek yerden. 17 ülke EETS uyumlu. Basit faturalandırma.',
+                'creditcard' => 'Kredi kontrolsüz ön ödemeli kart. TIR şoförleri için ideal. Tam maliyet kontrolü.',
+                'telematics' => 'GPS takipli profesyonel filo yönetimi. KITIN telematik Avrupa çözümü.'
+            ],
+            'en' => [
+                'fuelcard' => 'European fuel card for businesses. Cheap diesel, 19 countries, no fees. Apply now!',
+                'toll' => 'European truck toll solution. EETS compatible for 17 countries. Simple billing.',
+                'creditcard' => 'Prepaid business credit card without credit check. Perfect for truck drivers.',
+                'telematics' => 'Professional fleet management with GPS tracking. KITIN telematics for Europe.'
+            ]
+        ];
+        
+        return $descriptions[$lang][$focus] ?? $descriptions[$lang]['fuelcard'];
+    }
+}
+
+// Generator ausführen
+$generator = new SEOPageGenerator();
+$generator->generateAllPages();
+echo "SEO Pages generated successfully!\n";
+?>

--- a/js/seo-analytics.js
+++ b/js/seo-analytics.js
@@ -268,3 +268,31 @@ class SEOAnalytics {
 }
 
 window.seoAnalytics = new SEOAnalytics();
+
+// SEO Landing Page Tracking
+function trackSEOLandingPage() {
+    const currentUrl = window.location.href;
+
+    if (currentUrl.includes('/seo/') && window.gtag) {
+        const pageName = currentUrl.split('/').pop().replace('.html', '');
+
+        gtag('event', 'seo_landing_page_view', {
+            event_category: 'SEO',
+            event_label: pageName,
+            value: 1
+        });
+
+        // Track redirect
+        setTimeout(() => {
+            gtag('event', 'seo_page_redirect', {
+                event_category: 'SEO',
+                event_label: pageName
+            });
+        }, 3000);
+    }
+}
+
+// Initialize on SEO pages
+if (window.location.href.includes('/seo/')) {
+    trackSEOLandingPage();
+}

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,6 @@
 User-agent: *
 Allow: /
+Allow: /seo/
+
 Sitemap: https://www.filo.cards/sitemap.xml
+Sitemap: https://www.filo.cards/sitemap-seo.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,41 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  
-  <!-- Main Page (supports all languages via JavaScript) -->
-  <url>
-    <loc>https://www.filo.cards/</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-
-  <!-- Service Pages (Virtual URLs for SEO) -->
-  <url>
-    <loc>https://www.filo.cards/tankkarte</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://www.filo.cards/kreditkarte</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://www.filo.cards/maut</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://www.filo.cards/kontakt</loc>
-    <lastmod>2025-07-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-</urlset>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://www.filo.cards/sitemap.xml</loc>
+    <lastmod>2025-01-19</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.filo.cards/sitemap-seo.xml</loc>
+    <lastmod>2025-01-19</lastmod>
+  </sitemap>
+</sitemapindex>

--- a/translations-loader.php
+++ b/translations-loader.php
@@ -1,0 +1,9 @@
+<?php
+function loadTranslations($file = 'data/translations.json') {
+    if (!file_exists($file)) {
+        throw new Exception("Translations file not found: {$file}");
+    }
+    $json = file_get_contents($file);
+    return json_decode($json, true);
+}
+?>


### PR DESCRIPTION
## Summary
- add PHP generator for SEO landing pages
- integrate clean URLs and sitemaps for generated pages
- extend feature flags and admin panel for SEO pages
- log SEO page views in seo-analytics.js
- **remove webhook.php from repository**

## Testing
- `php -l generate-seo-pages.php`
- `php generate-seo-pages.php | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_687a3f2f41548323a8f8f18d59a3a418