### PR TITLE
Replace JSON fallback with ultra-minimal version

### DIFF
--- a/json-parser-fallback.php
+++ b/json-parser-fallback.php
@@ -1,98 +1,35 @@
 <?php
-// Memory-optimized JSON Parser Fallback - only used when native JSON unavailable
+// Ultra-minimal JSON fallback for webhook.php only
+// Only handles specific case: json_encode(['files' => array_of_strings])
 
-// Early exit if native JSON functions exist
-if (function_exists('json_decode') && function_exists('json_encode')) {
-    return; // Don't load fallback at all
-}
-
-class JSONParserFallback {
-    public static function decode($json, $assoc = false) {
-        // Use native if available (double-check)
-        if (function_exists('json_decode')) {
-            return json_decode($json, $assoc);
-        }
-        
-        // Memory-efficient simple fallback for basic cases only
-        $json = trim($json);
-        if (empty($json)) {
-            return null;
-        }
-        
-        // Only handle simple objects/arrays to avoid memory issues
-        if (strlen($json) > 1000000) { // 1MB limit
-            trigger_error('JSON too large for fallback parser', E_USER_WARNING);
-            return null;
-        }
-        
-        return self::simpleJSONDecode($json, $assoc);
-    }
-    
-    public static function encode($value, $options = 0) {
-        // Use native if available
-        if (function_exists('json_encode')) {
-            return json_encode($value, $options);
-        }
-        
-        return self::simpleJSONEncode($value);
-    }
-    
-    private static function simpleJSONDecode($json, $assoc = false) {
-        // Basic eval-based approach for emergency cases only
-        $json = trim($json);
-        if (substr($json, 0, 1) === '{' && substr($json, -1) === '}') {
-            // Simple object conversion
-            $php = str_replace(['{', '}', ':', 'true', 'false', 'null'], 
-                              ['array(', ')', '=>', 'true', 'false', 'null'], $json);
-            $php = preg_replace('/"([^"\\]+)"\s*=>/', '"$1" =>', $php);
-            
-            $result = null;
-            @eval('$result = ' . $php . ';');
-            return $result;
-        }
-        return null;
-    }
-    
-    private static function simpleJSONEncode($value) {
-        if (is_array($value) && count($value) < 100) { // Limit array size
-            $isAssoc = (array_keys($value) !== range(0, count($value) - 1));
-            
-            if ($isAssoc) {
-                $items = [];
-                foreach ($value as $key => $val) {
-                    $items[] = '"' . addslashes($key) . '":' . self::simpleJSONEncode($val);
-                }
-                return '{' . implode(',', $items) . '}';
-            } else {
-                $items = [];
-                foreach ($value as $val) {
-                    $items[] = self::simpleJSONEncode($val);
-                }
-                return '[' . implode(',', $items) . ']';
+if (!function_exists('json_encode')) {
+    function json_encode($value, $options = 0) {
+        // Handle only the specific Cloudflare cache purge case
+        if (is_array($value) && isset($value['files']) && is_array($value['files'])) {
+            $urls = [];
+            foreach ($value['files'] as $url) {
+                $urls[] = '"' . addslashes($url) . '"';
             }
-        } elseif (is_string($value)) {
-            return '"' . addslashes($value) . '"';
-        } elseif (is_bool($value)) {
-            return $value ? 'true' : 'false';
-        } elseif (is_null($value)) {
-            return 'null';
-        } elseif (is_numeric($value)) {
-            return $value;
+            return '{"files":[' . implode(',', $urls) . ']}';
         }
         return 'null';
     }
 }
 
-// Only register fallback functions if native ones don't exist
 if (!function_exists('json_decode')) {
     function json_decode($json, $assoc = false) {
-        return JSONParserFallback::decode($json, $assoc);
-    }
-}
-
-if (!function_exists('json_encode')) {
-    function json_encode($value, $options = 0) {
-        return JSONParserFallback::encode($value, $options);
+        // Ultra-basic decode for simple cases only
+        if (trim($json) === 'null') return null;
+        if (trim($json) === 'true') return true;
+        if (trim($json) === 'false') return false;
+        if (is_numeric(trim($json))) return (float)trim($json);
+        
+        // For Cloudflare response: just check if it contains "success":true
+        if (strpos($json, '"success":true') !== false) {
+            return $assoc ? ['success' => true] : (object)['success' => true];
+        }
+        
+        return null;
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- slim down `json-parser-fallback.php` to a minimal implementation
- fallback now only supports the Cloudflare webhook use case

## Testing
- `php -l json-parser-fallback.php`

------
https://chatgpt.com/codex/tasks/task_e_687a7077074083238963939833e46f09